### PR TITLE
fix 'time': is not a member of 'std' error for clang-cl builds on windows

### DIFF
--- a/include/ideep/utils.hpp
+++ b/include/ideep/utils.hpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <vector>
 #include <iterator>
+#include <ctime>
 #ifdef IDEEP_USE_MKL
 #include <mkl_vsl.h>
 #include <mkl_vml_functions.h>
@@ -30,9 +31,6 @@
 // Definitions for builtins unavailable on MSVC
 //see https://github.com/llvm/llvm-project/blob/master/compiler-rt/lib/builtins/int_lib.h
 #if defined(_MSC_VER) && !defined(__clang__)
-// <ctime> not need in VS pro 1.0.1, but for VS commun,
-// has error C2039: 'time': is not a member of 'std'.
-#include <ctime>
 #include <intrin.h>
 uint32_t __inline clz(uint32_t x) {
   unsigned long leading_zero = 0;


### PR DESCRIPTION
Fix  https://app.circleci.com/pipelines/github/pytorch/pytorch/143318/workflows/2d8b7692-5644-4166-ab9a-9339b4154749/jobs/4888269 broken which said error: **no member named 'time' in namespace 'std'**.