### PR TITLE
Asymmetric quantization for conv and other two improvements

### DIFF
--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -136,7 +136,9 @@ private:
       }
 
       // determine dst data type
-      if (dst_scales.empty() || dst_scales == IDEEP_DEF_SCALE) {
+      if (dst.get_data_type() != data_type::undef) {
+        dst_data_type = dst.get_data_type();
+      } else if (dst_scales.empty() || dst_scales == IDEEP_DEF_SCALE) {
         dst_data_type = data_type::f32;
       } else if (attr.non_negitive_output()) {
         dst_data_type = data_type::u8;


### PR DESCRIPTION
1. Support asymmetric quantization for conv
2. Use dst data type directly if it is already defined for quantization
3. Use f32 bias instead of s32 to improve accuracy for quantization