### PR TITLE
Update ip and matmul logical

### DIFF
--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -204,7 +204,7 @@ private:
     // If dst is not empty, ideep must write result to dst's memory and it is caller's duty to 
     // make sure dst is big enough to hold the result 
     if (dst.is_empty())
-      dst.reinit_if_possible(pd.dst_desc());
+      dst.init(pd.dst_desc());
     auto expected_dst = dst.reorder_if_differ_in(pd.dst_desc());
     if (!dst_scales.empty() && utils::one_of(dst.get_data_type(), data_type::u8, data_type::s8)) {
       expected_dst.set_scale(dst_scales_in);
@@ -275,7 +275,7 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
     // see [Notes output buffer]
     if (diff_src.is_empty())
-      diff_src.reinit_if_possible(pd.diff_src_desc());
+      diff_src.init(pd.diff_src_desc());
     auto expected_diff_src = diff_src.reorder_if_differ_in(pd.diff_src_desc());
 
     super(pd).execute(stream::default_stream(),
@@ -353,7 +353,7 @@ private:
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     if (diff_weights.is_empty())
-      diff_weights.reinit_if_possible(pd.diff_weights_desc());
+      diff_weights.init(pd.diff_weights_desc());
     auto expected_diff_weights = diff_weights.reorder_if_differ_in(pd.diff_weights_desc());
 
     exec_args args {{DNNL_ARG_DIFF_DST, expected_diff_dst},
@@ -364,7 +364,7 @@ private:
     if (with_diff_bias) {
       // reorder diff_bias(grad_b)
       if (diff_bias.is_empty())
-        diff_bias.reinit_if_possible(pd.diff_bias_desc());
+        diff_bias.init(pd.diff_bias_desc());
       expected_diff_bias = diff_bias.reorder_if_differ_in(pd.diff_bias_desc());
       args.insert({DNNL_ARG_DIFF_BIAS, expected_diff_bias});
     }

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -201,12 +201,12 @@ private:
 
     // [ Note output buffer]
     // In this case, dst is an empty ideep tensor, can be re-init
-    // If dst is not empty, ideep must wirte result to dst's memory and it is caller's duty to 
+    // If dst is not empty, ideep must write result to dst's memory and it is caller's duty to 
     // make sure dst is big enough to hold the result 
     if (dst.is_empty())
       dst.reinit_if_possible(pd.dst_desc());
     auto expected_dst = dst.reorder_if_differ_in(pd.dst_desc());
-    if (!dst_scales.empty() && (dst.get_data_type() != data_type::f32 || dst.get_data_type() != data_type::bf16)) {
+    if (!dst_scales.empty() && utils::one_of(dst.get_data_type(), data_type::u8, data_type::s8)) {
       expected_dst.set_scale(dst_scales_in);
     }
 

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -260,12 +260,12 @@ private:
 
     // [ Note output buffer]
     // In this case, dst is an empty ideep tensor, can be re-init
-    // If dst is not empty, ideep must wirte result to dst's memory and it is caller's duty to 
+    // If dst is not empty, ideep must write result to dst's memory and it is caller's duty to 
     // make sure dst is big enough to hold the result 
     if (dst.is_empty())
       dst.reinit_if_possible(pd.dst_desc());
     auto expected_dst = dst.reorder_if_differ_in(pd.dst_desc());
-    if (!dst_scales.empty() && (dst.get_data_type() != data_type::f32 || dst.get_data_type() != data_type::bf16)) {
+    if (!dst_scales.empty() && utils::one_of(dst.get_data_type(), data_type::u8, data_type::s8)) {
       expected_dst.set_scale(dst_scales_in);
     }
 

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -263,7 +263,7 @@ private:
     // If dst is not empty, ideep must write result to dst's memory and it is caller's duty to 
     // make sure dst is big enough to hold the result 
     if (dst.is_empty())
-      dst.reinit_if_possible(pd.dst_desc());
+      dst.init(pd.dst_desc());
     auto expected_dst = dst.reorder_if_differ_in(pd.dst_desc());
     if (!dst_scales.empty() && utils::one_of(dst.get_data_type(), data_type::u8, data_type::s8)) {
       expected_dst.set_scale(dst_scales_in);

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -663,6 +663,13 @@ class tensor : public memory {
     }
   }
 
+  void reorder_to_if_differ_from(tensor &dst, const attr_t &aattr = attr_t()) const {
+    if (dst.get_desc() != get_desc()) {
+      this->reorder_to(dst, aattr);
+    }
+    return;
+  }
+
   // workaround for issue intel/mkl-dnn#588
   desc _get_unblocked_desc_if_4c_blocked() const {
     auto desc = get_desc();

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -663,6 +663,7 @@ class tensor : public memory {
     }
   }
 
+  // Copy data from *this to dst if dst's memory desc(size, stride, format, etc) is different from *this;
   void reorder_to_if_differ_from(tensor &dst, const attr_t &aattr = attr_t()) const {
     if (dst.get_desc() != get_desc()) {
       this->reorder_to(dst, aattr);

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -663,7 +663,7 @@ class tensor : public memory {
     }
   }
 
-  // Copy data from *this to dst if dst's memory desc(size, stride, format, etc) is different from *this;
+  // Reorder data from *this to dst if dst's memory desc(size, stride, format, etc) is different from *this;
   void reorder_to_if_differ_from(tensor &dst, const attr_t &aattr = attr_t()) const {
     if (dst.get_desc() != get_desc()) {
       this->reorder_to(dst, aattr);


### PR DESCRIPTION
## Principle:
- always query expected data format from onednn. If  cannot minimize time usage (include format conversion + gemm computation) with this behavior, this should be an issue to report to onednn.
- If given output buffer by user, we should always written to the given buffer(caller's duty to give a output buffer with enough storage). If onednn dose not support or have poor performance with writing to given strided buffer, we now temporarily perform "copy" behavior to copy result from onednn expected buffer to user gived buffer. But for long term, onednn should have good performance writing to given strided buffer.

