### PR TITLE
Refactor matmul API

### DIFF
--- a/include/ideep/abstract_types.hpp
+++ b/include/ideep/abstract_types.hpp
@@ -52,6 +52,9 @@ using key_t = std::string;
 #endif
 
 const scale_t IDEEP_DEF_SCALE {1.0f};
+const zero_point_t IDEEP_DEF_ZP {0};
+const scale_t IDEEP_EMPTY_SCALE;
+const zero_point_t IDEEP_EMPTY_ZP;
 
 enum lowp_kind {
   u8s8 = 0,

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -24,12 +24,12 @@ struct inner_product_forward_params {
       attr_t&& src_attr,
       attr_t&& weights_attr,
       attr_t&& bias_attr)
-      : _pd(pd),
-        _primitive(primitive),
-        _op_attr(op_attr),
-        _src_attr(src_attr),
-        _weights_attr(weights_attr),
-        _bias_attr(bias_attr) {}
+      : _pd(std::move(pd)),
+        _primitive(std::move(primitive)),
+        _op_attr(std::move(op_attr)),
+        _src_attr(std::move(src_attr)),
+        _weights_attr(std::move(weights_attr)),
+        _bias_attr(std::move(bias_attr)) {}
 };
 
 struct inner_product_forward

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -3,43 +3,107 @@
 
 namespace ideep {
 
+// Note:
+// Inner product does not support quantization.
+// Please switch to matmul for quantized *mm ops
+
+struct inner_product_forward_params {
+  dnnl::inner_product_forward::primitive_desc _pd;
+  dnnl::inner_product_forward _primitive;
+  attr_t _op_attr;
+  attr_t _src_attr;
+  attr_t _weights_attr;
+  attr_t _bias_attr;
+
+  inner_product_forward_params() {}
+
+  inner_product_forward_params(
+      dnnl::inner_product_forward::primitive_desc&& pd,
+      dnnl::inner_product_forward&& primitive,
+      attr_t&& op_attr,
+      attr_t&& src_attr,
+      attr_t&& weights_attr,
+      attr_t&& bias_attr)
+      : _pd(pd),
+        _primitive(primitive),
+        _op_attr(op_attr),
+        _src_attr(src_attr),
+        _weights_attr(weights_attr),
+        _bias_attr(bias_attr) {}
+};
+
 struct inner_product_forward
     : public dnnl::inner_product_forward,
       utils::computation_cache<dnnl::inner_product_forward::primitive_desc> {
   using super = dnnl::inner_product_forward;
 
+  // 2-in-1 compute, with bias
   static void compute(const tensor& src,
                       const tensor& weights,
                       const tensor& bias,
                       tensor& dst,
-                      const scale_t& src_scales = scale_t(),
-                      const scale_t& weights_scales = scale_t(),
-                      const scale_t& dst_scales = scale_t(),
                       const attr_t& attr = attr_t(),
                       const prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
                       const engine& aengine = engine::cpu_engine()) {
-    compute_impl</*with_bias=*/true>(src, weights, bias, dst, src_scales,
-                                     weights_scales, dst_scales, attr,
-                                     aprop_kind, alowp_kind, aengine);
+    compute_impl</*with_bias=*/true>(src, weights, bias, dst, attr,
+                                     aprop_kind, aengine);
   }
 
+  // 2-in-1 compute, without bias
   static void compute(const tensor& src,
                       const tensor& weights,
                       tensor& dst,
-                      const scale_t& src_scales = scale_t(),
-                      const scale_t& weights_scales = scale_t(),
-                      const scale_t& dst_scales = scale_t(),
                       const attr_t& attr = attr_t(),
                       const prop_kind aprop_kind = prop_kind::forward,
-                      const lowp_kind alowp_kind = u8s8,
                       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst, src_scales,
-                                      weights_scales, dst_scales, attr,
-                                      aprop_kind, alowp_kind, aengine);
+    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst, attr,
+                                      aprop_kind, aengine);
   }
 
+  // Prepare with bias
+  static void prepare(inner_product_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst,
+                      const attr_t& attr = attr_t(),
+                      const prop_kind aprop_kind = prop_kind::forward,
+                      const engine& aengine = engine::cpu_engine()) {
+    do_prepare</*with_bias=*/true>(param, src, weights, bias, dst, attr,
+                                   aprop_kind, aengine);
+  }
+
+  // Prepare without bias
+  static void prepare(inner_product_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      tensor& dst,
+                      const attr_t& attr = attr_t(),
+                      const prop_kind aprop_kind = prop_kind::forward,
+                      const engine& aengine = engine::cpu_engine()) {
+    static tensor dummy_bias;
+    do_prepare</*with_bias=*/false>(param, src, weights, dummy_bias, dst, attr,
+                                   aprop_kind, aengine);
+  }
+
+  // Compute with prepared param, with bias
+  static void compute(const inner_product_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst) {
+    do_compute</*with_bias=*/true>(param, src, weights, bias, dst);
+  }
+
+  // Compute with prepared param, without bias
+  static void compute(const inner_product_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      tensor& dst) {
+    static tensor dummy_bias;
+    do_compute</*with_bias=*/false>(param, src, weights, dummy_bias, dst);
+  }
 
   static tensor::desc expected_weights_desc(
       const dims& weights_dims,
@@ -101,24 +165,25 @@ private:
                            const tensor& weights,
                            const tensor& bias,
                            tensor& dst,
-                           const scale_t& src_scales,
-                           const scale_t& weights_scales,
-                           const scale_t& dst_scales,
                            const attr_t& attr,
                            const prop_kind aprop_kind,
-                           const lowp_kind alowp_kind,
                            const engine& aengine) {
+    inner_product_forward_params param;
     // workaround: src and weights from caffe2 may have different dims.
     // It would be better for caffe2 to do this reshape anyway.
-    auto src_ = src;
     if (src.ndims() != weights.ndims()) {
+      auto src_ = src;
       auto new_dims = weights.get_dims();
       new_dims[0] = src.get_dim(0);
       src_.reshape(new_dims);
+      do_prepare_<with_bias>(param, src_, weights, bias, dst, attr, aprop_kind, aengine);
+      do_compute_<with_bias>(param, src_, weights, bias, dst);
+    } else {
+      do_prepare_<with_bias>(param, src, weights, bias, dst, attr, aprop_kind, aengine);
+      do_compute_<with_bias>(param, src, weights, bias, dst);
     }
-    compute_impl_<with_bias>(src_, weights, bias, dst, src_scales,
-                             weights_scales, dst_scales, attr, aprop_kind,
-                             alowp_kind, aengine);
+    // compute_impl_<with_bias>(src_, weights, bias, dst, attr,
+                             // aprop_kind, aengine);
   }
 
   template <bool with_bias>
@@ -126,12 +191,8 @@ private:
                             const tensor& weights,
                             const tensor& bias,
                             tensor& dst,
-                            const scale_t& src_scales,
-                            const scale_t& weights_scales,
-                            const scale_t& dst_scales,
                             const attr_t& attr,
                             const prop_kind aprop_kind,
-                            const lowp_kind alowp_kind,
                             const engine& aengine) {
     tensor::desc src_desc, weights_desc, bias_desc;
     attr_t op_attr, src_attr, weights_attr, bias_attr;
@@ -139,86 +200,27 @@ private:
     data_type dst_data_type;
     auto dst_dims = {src.get_dim(0), weights.get_dim(0)};
 
-    auto weights_scales_in =
-        weights.has_scale() ? weights.get_scale() : weights_scales;
+    op_attr = attr;
+    if (src.has_scale()) {
+      auto src_scale = src.get_scale();
+      src_scale[0] = 1.f / src_scale[0];
+      src_attr = {0, src_scale};
+    }
 
-    // TODO(xpz): Remove int8 inner product implementation. We are switching to
-    // matmul for quantized *mm ops
-    if (!weights_scales_in.empty()) {
-      IDEEP_ENFORCE(alowp_kind == u8s8 || alowp_kind == s8s8,
-                    "Unsupported lowp kind");
+    IDEEP_ENFORCE(utils::one_of(weights.get_data_type(),
+                                data_type::f32, data_type::bf16),
+            "Incorrect data type in weights");
 
-      auto src_scales_in =
-          src.has_scale() ? src.get_scale()
-                          : src_scales.empty() ? IDEEP_DEF_SCALE : src_scales;
-
-      src_desc = {src.get_dims(),
-                  alowp_kind == u8s8 ? data_type::u8 : data_type::s8,
-                  tag::any};
-      if (src.get_data_type() == data_type::f32) {
-        src_attr = {0, src_scales_in};
-      }
-
-      int scale_size = weights_scales_in.size() > 1 ? weights.get_dim(0) : 1;
-
-      weights_desc = {weights.get_dims(), data_type::s8, tag::any};
-      if (weights.get_data_type() == data_type::f32) {
-        weights_attr = {utils::tensor_scale_mask(scale_size, false),
-                        weights_scales_in};
-      }
-
-      // determine dst data type
-      if (dst.get_data_type() != data_type::undef) {
-        dst_data_type = dst.get_data_type();
-      } else if (dst_scales.empty() || dst_scales == IDEEP_DEF_SCALE) {
-        dst_data_type = data_type::f32;
-      } else if (attr.non_negitive_output()) {
-        dst_data_type = data_type::u8;
-      } else {
-        dst_data_type = data_type::s8;
-      }
-
-      // fill primitive attr
-      scale_t op_scales(scale_size), bias_scales(scale_size);
-      dst_scales_in = dst_scales.empty() || dst_data_type == data_type::f32
-                          ? IDEEP_DEF_SCALE
-                          : dst_scales;
-      for (int i = 0; i < scale_size; i++) {
-        bias_scales[i] = src_scales_in[0] * weights_scales_in[i];
-        op_scales[i] = dst_scales_in[0] / bias_scales[i];
-      }
-      op_attr.set_output_scales(utils::op_scale_mask(scale_size), op_scales);
-
-      if (with_bias) {
-        bias_desc = {bias.get_dims(), data_type::s32, format_tag::any};
-        if (bias.get_data_type() == data_type::f32) {
-          bias_attr = {utils::tensor_scale_mask(scale_size, false),
-                       bias_scales};
-        }
-      }
-    } else {
-      op_attr = attr;
-      if (src.has_scale()) {
-        auto src_scale = src.get_scale();
-        src_scale[0] = 1.f / src_scale[0];
-        src_attr = {0, src_scale};
-      }
-
-      IDEEP_ENFORCE(utils::one_of(weights.get_data_type(),
+    // align weights data type with src
+    dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
+                                                           : data_type::f32;
+    src_desc = {src.get_dims(), dst_data_type, format_tag::any};
+    weights_desc = {weights.get_dims(), dst_data_type, format_tag::any};
+    if (with_bias) {
+      IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
                                   data_type::f32, data_type::bf16),
-              "Incorrect data type in weights");
-
-      // align weights data type with src
-      dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
-                                                             : data_type::f32;
-      src_desc = {src.get_dims(), dst_data_type, format_tag::any};
-      weights_desc = {weights.get_dims(), dst_data_type, format_tag::any};
-      if (with_bias) {
-        IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
-                                    data_type::f32, data_type::bf16),
-                      "Incorrect data type in bias");
-        bias_desc = bias.get_desc().to_format_any();
-      }
+                    "Incorrect data type in bias");
+      bias_desc = bias.get_desc().to_format_any();
     }
 
     tensor::desc dst_desc(dst_dims, dst_data_type, format_tag::any);
@@ -236,12 +238,12 @@ private:
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc(), src_attr);
     auto expected_weights = weights.reorder_if_differ_in(pd.weights_desc(), weights_attr);
-  
+
     tensor expected_dst;
     if (dst.is_empty() || dst.get_desc() != pd.dst_desc()){
       // If dst buffer are not given by user or user given dst buffer are not under expected format
-      // We need init a new one. "dst.get_desc() != pd.dst_desc()" conditional is setting for 
-      // caffe2 caller, it might given a non-empty but uncorrect dst (maybe the size is uncorrect) 
+      // We need init a new one. "dst.get_desc() != pd.dst_desc()" conditional is setting for
+      // caffe2 caller, it might given a non-empty but uncorrect dst (maybe the size is uncorrect)
       expected_dst.init(pd.dst_desc());
       if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
         // We need copy the content of given buffer if ip is fused with sum
@@ -250,10 +252,6 @@ private:
     } else {
       // The format of given dst buffer is expected
       expected_dst = dst;
-    }
-
-    if (!dst_scales.empty() && utils::one_of(dst.get_data_type(), data_type::u8, data_type::s8)) {  
-      expected_dst.set_scale(dst_scales_in);
     }
 
     tensor scratchpad(pd.scratchpad_desc());
@@ -274,13 +272,173 @@ private:
                          {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
 
-    if (attr.non_negitive_output() && expected_dst.get_data_type() == data_type::s8) {
-      expected_dst.to_type(data_type::u8);
-    }
     // reorder back to dst's buffer if needed
-    if (dst.is_empty() || 
-        // when dst is empty, expect return buffer allocate by ideep  
-        dst.get_desc() == expected_dst.get_desc() || 
+    if (dst.is_empty() ||
+        // when dst is empty, expect return buffer allocate by ideep
+        dst.get_desc() == expected_dst.get_desc() ||
+        // dst and expected_dst is the same under this case
+        !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
+        // for caffe2 caller, get an uncorrect size dst from caller, can return buffer allocate by ideep
+      dst =  expected_dst;
+    } else {
+      dst.feed_from(expected_dst);
+    }
+  }
+
+  template <bool with_bias>
+  static void do_prepare(
+      inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr,
+      const prop_kind aprop_kind,
+      const engine& aengine) {
+    // workaround: src and weights from caffe2 may have different dims.
+    // It would be better for caffe2 to do this reshape anyway.
+    if (src.ndims() != weights.ndims()) {
+      auto src_ = src;
+      auto new_dims = weights.get_dims();
+      new_dims[0] = src.get_dim(0);
+      src_.reshape(new_dims);
+      do_prepare_<with_bias>(param, src_, weights, bias, dst, attr, aprop_kind, aengine);
+    } else {
+      do_prepare_<with_bias>(param, src, weights, bias, dst, attr, aprop_kind, aengine);
+    }
+  }
+
+  template <bool with_bias>
+  static void do_prepare_(
+      inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const attr_t& attr,
+      const prop_kind aprop_kind,
+      const engine& aengine) {
+    tensor::desc src_desc, weights_desc, bias_desc;
+    attr_t& op_attr = param._op_attr;
+    attr_t& src_attr = param._src_attr;
+    attr_t& weights_attr = param._weights_attr;
+    attr_t& bias_attr = param._bias_attr;
+    scale_t dst_scales_in;
+    data_type dst_data_type;
+    auto dst_dims = {src.get_dim(0), weights.get_dim(0)};
+
+    op_attr = attr;
+    if (src.has_scale()) {
+      auto src_scale = src.get_scale();
+      src_scale[0] = 1.f / src_scale[0];
+      src_attr = {0, src_scale};
+    }
+
+    IDEEP_ENFORCE(utils::one_of(weights.get_data_type(),
+                                data_type::f32, data_type::bf16),
+            "Incorrect data type in weights");
+
+    // align weights data type with src
+    dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
+                                                           : data_type::f32;
+    src_desc = {src.get_dims(), dst_data_type, format_tag::any};
+    weights_desc = {weights.get_dims(), dst_data_type, format_tag::any};
+    if (with_bias) {
+      IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
+                                  data_type::f32, data_type::bf16),
+                    "Incorrect data type in bias");
+      bias_desc = bias.get_desc().to_format_any();
+    }
+
+    tensor::desc dst_desc(dst_dims, dst_data_type, format_tag::any);
+
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    param._pd = get_primitive_desc(
+        src_desc,
+        weights_desc,
+        dst_desc,
+        bias_desc,
+        with_bias,
+        op_attr,
+        aprop_kind);
+    param._primitive = std::move(super(param._pd));
+  }
+
+  template <bool with_bias>
+  static void do_compute(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
+    // workaround: src and weights from caffe2 may have different dims.
+    // It would be better for caffe2 to do this reshape anyway.
+    if (src.ndims() != weights.ndims()) {
+      auto src_ = src;
+      auto new_dims = weights.get_dims();
+      new_dims[0] = src.get_dim(0);
+      src_.reshape(new_dims);
+      do_compute_<with_bias>(param, src_, weights, bias, dst);
+    } else {
+      do_compute_<with_bias>(param, src, weights, bias, dst);
+    }
+  }
+
+  template <bool with_bias>
+  static void do_compute_(
+      const inner_product_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
+    auto& pd = param._pd;
+    auto& primitive = param._primitive;
+    auto& op_attr = param._op_attr;
+    auto& src_attr = param._src_attr;
+    auto& weights_attr = param._weights_attr;
+    auto& bias_attr = param._bias_attr;
+
+    auto expected_src = src.reorder_if_differ_in(pd.src_desc(), src_attr);
+    auto expected_weights = weights.reorder_if_differ_in(pd.weights_desc(), weights_attr);
+
+    tensor expected_dst;
+    if (dst.is_empty() || dst.get_desc() != pd.dst_desc()){
+      // If dst buffer are not given by user or user given dst buffer are not under expected format
+      // We need init a new one. "dst.get_desc() != pd.dst_desc()" conditional is setting for
+      // caffe2 caller, it might given a non-empty but uncorrect dst (maybe the size is uncorrect)
+      expected_dst.init(pd.dst_desc());
+      if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
+        // We need copy the content of given buffer if ip is fused with sum
+        expected_dst.feed_from(dst);
+      }
+    } else {
+      // The format of given dst buffer is expected
+      expected_dst = dst;
+    }
+
+    tensor scratchpad(pd.scratchpad_desc());
+
+    if (with_bias){
+      auto expected_bias = bias.reorder_if_differ_in(pd.bias_desc(), bias_attr);
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_BIAS, expected_bias},
+                         {DNNL_ARG_DST, expected_dst},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    } else {
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_DST, expected_dst},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    }
+
+    // reorder back to dst's buffer if needed
+    if (dst.is_empty() ||
+        // when dst is empty, expect return buffer allocate by ideep
+        dst.get_desc() == expected_dst.get_desc() ||
         // dst and expected_dst is the same under this case
         !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
         // for caffe2 caller, get an uncorrect size dst from caller, can return buffer allocate by ideep
@@ -349,8 +507,8 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
                        {DNNL_ARG_DIFF_SRC, expected_diff_src},
                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
     // reorder back to diff_src's buffer if needed
-    if (diff_src.is_empty() || 
-         diff_src.get_desc() == expected_diff_src.get_desc() || 
+    if (diff_src.is_empty() ||
+         diff_src.get_desc() == expected_diff_src.get_desc() ||
          !diff_src.get_desc().has_same_shape_as(expected_diff_src.get_desc())){
       diff_src = expected_diff_src;
     } else {
@@ -449,8 +607,8 @@ private:
 
     super(pd).execute(stream::default_stream(), args);
       // reorder back to diff_weights's buffer if needed
-    if (diff_weights.is_empty() || 
-         diff_weights.get_desc() == expected_diff_weights.get_desc() || 
+    if (diff_weights.is_empty() ||
+         diff_weights.get_desc() == expected_diff_weights.get_desc() ||
          !diff_weights.get_desc().has_same_shape_as(expected_diff_weights.get_desc())){
       diff_weights = expected_diff_weights;
     } else {

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -581,9 +581,6 @@ private:
       do_prepare<with_bias>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
                  attr, dst_type, aengine);
     }
-    // do_prepare(param, type_prepare_static, src, weights, bias, with_bias, dst, dst_coeff, sum_coeff,
-               // src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-               // attr, dst_type, alowp_kind, aengine);
     do_compute<with_bias, /*reorder_src=*/ true, /*reorder_weight=*/ true>(
         param, src, weights, bias, dst);
   }
@@ -670,12 +667,6 @@ private:
       }
     });
     param._primitive = std::move(super(param._pd));
-    // param._primitive = std::move(super(pd));
-    // param._pd = std::move(pd);
-    // param._op_attr = std::move(op_attr);
-    // param._src_attr = std::move(src_attr);
-    // param._weights_attr = std::move(weights_attr);
-    // param._bias_attr = std::move(bias_attr);
  }
 
   // For static int8 op (int8 * int8 -> int8)
@@ -826,13 +817,6 @@ private:
       }
     });
     param._primitive = std::move(super(param._pd));
-    // param._primitive = std::move(super(pd));
-    // param._pd = std::move(pd);
-    // param._op_attr = std::move(op_attr);
-
-    // param._src_attr = std::move(src_attr);
-    // param._weights_attr = std::move(weights_attr);
-    // param._bias_attr = std::move(bias_attr);
  }
 
   // For dynamic int8 op (fp32 * int8 -> fp32)
@@ -932,7 +916,6 @@ private:
     // Create pd and primitive
     param._pd = primitive_desc({src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
     param._primitive = super(param._pd);
-    // param._op_attr = std::move(op_attr);
 
     // Create src reorder primitive with runtime scales/zero point
     auto src_reorder_pd = dnnl::reorder::primitive_desc(aengine, src.get_desc(), aengine, src_desc, src_attr);
@@ -1032,33 +1015,6 @@ private:
       }
     }
 
-/*     if (with_bias){
-      auto& expected_bias = reorder_weight ?
-                           bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                           bias;
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_BIAS, expected_bias},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
-    } else {
-      primitive.execute(stream::default_stream(),
-                        {{DNNL_ARG_SRC, expected_src},
-                         {DNNL_ARG_WEIGHTS, expected_weights},
-                         {DNNL_ARG_DST, expected_dst},
-                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
-    }
-    if (reorder_src) {
-      // reorder back to dst's buffer if needed
-      if (dst.is_empty() ||
-            dst.get_desc() == expected_dst.get_desc() ||
-            !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
-        dst =  expected_dst;
-      } else {
-        dst.feed_from(expected_dst);
-      }
-    } */
   }
 
   // For dynamic int8 op (fp32 * int8 -> fp32)

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -3,27 +3,326 @@
 
 namespace ideep {
 
+// Parameters for dynamic quantization
+struct matmul_forward_dyn_quant_params {
+  scale_t weight_scales; // to compute output scales
+  tensor wei_zero_point_m; // for matmul computation
+  tensor::desc src_desc; // to create src tensor
+  dnnl::reorder::primitive src_reorder; // to reorder src
+};
+
+// Common parameters for computation
 struct matmul_forward_params {
   dnnl::matmul::primitive_desc pd;
   dnnl::matmul primitive;
   attr_t op_attr;
-  // bias_attr contains requantization scales for bias
-  attr_t bias_attr;
-  scale_t dst_scales;
+  attr_t bias_attr; // contains requantization scales for bias
   attr_t src_attr;
   attr_t weights_attr;
-  tensor::desc src_desc;
-  tensor::desc weights_desc;
-  tensor scales_m;
-  tensor src_zero_point_m;
-  tensor wei_zero_point_m;
-  tensor dst_zero_point_m;
+  std::shared_ptr<matmul_forward_dyn_quant_params> dq_param_ptr;
 };
 
 struct matmul_forward : public dnnl::matmul,
                         utils::computation_cache<dnnl::matmul::primitive_desc> {
   using super = dnnl::matmul;
 
+  // 2-in-1 compute for fp32 op with bias. Bias is disabled if it is empty.
+  static inline void compute(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f,
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::undef,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
+    if (bias.is_empty()) {
+      compute_impl</*with_bias=*/false>(src, weights, bias, dst,
+                                        IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
+                                        IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
+                                        dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    } else {
+      compute_impl</*with_bias=*/true>(src, weights, bias, dst,
+                                       IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
+                                       IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
+                                       dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    }
+  }
+
+  // 2-in-1 compute for fp32 op without bias.
+  static inline void compute(
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f,
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::undef,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
+    static tensor dummy_bias;
+    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst,
+                                      IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE, IDEEP_EMPTY_SCALE,
+                                      IDEEP_EMPTY_ZP, IDEEP_EMPTY_ZP,
+                                      dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+  }
+
+  // 2-in-1 compute for int8 op with bias. Bias is not used if it is empty.
+  static inline void compute(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_points,
+      const zero_point_t& dst_zero_points,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f,
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::undef,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
+    if (bias.is_empty()) {
+      compute_impl</*with_bias=*/false>(src, weights, bias, dst,
+                                        src_scales, weights_scales, dst_scales,
+                                        src_zero_points, dst_zero_points,
+                                        dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    } else {
+      compute_impl</*with_bias=*/true>(src, weights, bias, dst,
+                                       src_scales, weights_scales, dst_scales,
+                                       src_zero_points, dst_zero_points,
+                                       dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    }
+  }
+
+  // 2-in-1 compute for int8 op with bias. Bias is not used if it is empty.
+  static inline void compute(
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_points,
+      const zero_point_t& dst_zero_points,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f,
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::undef,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
+    static tensor dummy_bias;
+    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst,
+                                      src_scales, weights_scales, dst_scales,
+                                      src_zero_points, dst_zero_points,
+                                      dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+  }
+
+  // Prepare for fp32 op
+  // With bias. Bias is disabled if it is empty.
+  static inline void prepare(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f, // for post-op sum
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::f32,
+      const engine& aengine = engine::cpu_engine()) {
+    if (bias.is_empty()) {
+      do_prepare</*with_bias=*/false>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
+          attr, dst_type, aengine);
+    } else {
+      do_prepare</*with_bias=*/true>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
+          attr, dst_type, aengine);
+    }
+  }
+
+  // Prepare for fp32 op
+  // Without bias.
+  static inline void prepare(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const float dst_coeff, // default = 1.0f
+      const float sum_coeff, // for post-op sum, default = 1.0f
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::f32,
+      const engine& aengine = engine::cpu_engine()) {
+    static tensor dummy_bias;
+    do_prepare</*with_bias=*/false>(param, src, weights, dummy_bias, dst, dst_coeff, sum_coeff,
+        attr, dst_type, aengine);
+  }
+
+  // Prepare for int8 op with bias. Bias is not used if it is empty.
+  // Static: int8 * int8 -> int8. Dynamic: fp32 * int8 -> fp32
+  template <bool is_dynamic = false>
+  static inline void prepare(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_points,
+      const zero_point_t& dst_zero_points,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f, // for post-op sum
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::u8,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
+    if (is_dynamic) {
+      if (bias.is_empty()) {
+        do_prepare_dynamic_quant</*with_bias=*/false>(
+            param, src, weights, bias, dst, weights_scales,
+            sum_coeff, attr, data_type::f32, aengine);
+      } else {
+        do_prepare_dynamic_quant</*with_bias=*/true>(
+            param, src, weights, bias, dst, weights_scales,
+            sum_coeff, attr, data_type::f32, aengine);
+      }
+    } else {
+      if (bias.is_empty()) {
+        do_prepare_static_quant</*with_bias=*/false>(
+            param, src, weights, bias, dst,
+            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      } else {
+        do_prepare_static_quant</*with_bias=*/true>(
+            param, src, weights, bias, dst,
+            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      }
+    }
+  }
+
+  // Prepare for int8 op without bias.
+  // Static: int8 * int8 -> int8. Dynamic: fp32 * int8 -> fp32
+  template <bool is_dynamic = false>
+  static inline void prepare(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_points,
+      const zero_point_t& dst_zero_points,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f, // for post-op sum
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::u8,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
+    static tensor dummy_bias;
+    if (is_dynamic) {
+      do_prepare_dynamic_quant</*with_bias=*/false>(
+          param, src, weights, dummy_bias, dst, weights_scales,
+          sum_coeff, attr, data_type::f32, aengine);
+    } else {
+      do_prepare_static_quant</*with_bias=*/false>(
+          param, src, weights, dummy_bias, dst,
+          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+          dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    }
+  }
+
+  // Compute for fp32 and static int8 (int8 * int8 -> int8)
+  // With bias. Bias is not used if it is empty.
+  // Set reorder flags to false if you are sure the memory layout aligns
+  // with primitive descriptor. Otherwise, checks are made and reorder
+  // may be needed.
+  template <bool reorder_src = true, bool reorder_weight = true>
+  static inline void compute(const matmul_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      const tensor& bias,
+                      tensor& dst) {
+    if (bias.is_empty()) {
+      do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
+          param, src, weights, bias, dst);
+    } else {
+      do_compute</*with_bias=*/true, reorder_src, reorder_weight>(
+          param, src, weights, bias, dst);
+    }
+  }
+
+  // Compute for fp32 and static int8 (int8 * int8 -> int8)
+  // Without bias.
+  // Set reorder flags to false if you are sure the memory layout aligns
+  // with primitive descriptor. Otherwise, checks are made and reorder
+  // may be needed.
+  template <bool reorder_src = true, bool reorder_weight = true>
+  static inline void compute(const matmul_forward_params& param,
+                      const tensor& src,
+                      const tensor& weights,
+                      tensor& dst) {
+    static tensor dummy_bias;
+    do_compute</*with_bias=*/false, reorder_src, reorder_weight>(
+        param, src, weights, dummy_bias, dst);
+  }
+
+  // Compute for dynamic int8 (fp32 * int8 -> fp32)
+  // With bias. Bias is not used if it is empty.
+  // Set reorder flags to false if you are sure the memory layout aligns
+  // with primitive descriptor. Otherwise, checks are made and reorder
+  // may be needed.
+  template <bool reorder_weight = true>
+  static inline void compute(
+      const matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const scale_t& src_scales,
+      const zero_point_t& src_zero_points,
+      const float dst_coeff = 1.0f,
+      const engine& aengine = engine::cpu_engine()) {
+    if (bias.is_empty()) {
+      do_compute_dynamic_quant</*with_bias=*/false, reorder_weight>(
+          param, src, weights, bias, dst,
+          src_scales, src_zero_points, dst_coeff, aengine);
+    } else {
+      do_compute_dynamic_quant</*with_bias=*/true, reorder_weight>(
+          param, src, weights, bias, dst,
+          src_scales, src_zero_points, dst_coeff, aengine);
+    }
+  }
+
+  // Compute for dynamic int8 (fp32 * int8 -> fp32)
+  // Without bias.
+  // Set reorder flags to false if you are sure the memory layout aligns
+  // with primitive descriptor. Otherwise, checks are made and reorder
+  // may be needed.
+  template <bool reorder_weight = true>
+  static inline void compute(
+      const matmul_forward_params& param,
+      const matmul_forward_dyn_quant_params& dq_param,
+      const tensor& src,
+      const tensor& weights,
+      tensor& dst,
+      const scale_t& src_scales,
+      const zero_point_t& src_zero_points,
+      const float dst_coeff = 1.0f,
+      const engine& aengine = engine::cpu_engine()) {
+    static tensor dummy_bias;
+    do_compute_dynamic_quant</*with_bias=*/false, reorder_weight>(
+        param, src, weights, dummy_bias, dst,
+        src_scales, src_zero_points, dst_coeff, aengine);
+  }
+
+  // Deprecated 2-in-1 compute
   // With bias. Zero points are passed explicitly as arguments for quantization
   // Bias is not used if it is empty.
   static void compute_v2(
@@ -43,18 +342,19 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     if (bias.is_empty()) {
-      compute_impl</*with_bias=*/false>(src, weights, bias, dst, dst_coeff, sum_coeff,
+      compute_impl</*with_bias=*/false>(src, weights, bias, dst,
                                         src_scales, weights_scales, dst_scales,
                                         src_zero_points, dst_zero_points,
-                                        attr, dst_type, alowp_kind, aengine);
+                                        dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
     } else {
-      compute_impl</*with_bias=*/true>(src, weights, bias, dst, dst_coeff, sum_coeff,
+      compute_impl</*with_bias=*/true>(src, weights, bias, dst,
                                        src_scales, weights_scales, dst_scales,
                                        src_zero_points, dst_zero_points,
-                                       attr, dst_type, alowp_kind, aengine);
+                                       dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
     }
   }
 
+  // Deprecated 2-in-1 compute
   // Without bias. Zero points are passed explicitly as arguments for quantization
   static void compute_v2(
       const tensor& src,
@@ -72,13 +372,13 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst, dst_coeff,
-                                      sum_coeff, src_scales, weights_scales, dst_scales,
+    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst,
+                                      src_scales, weights_scales, dst_scales,
                                       src_zero_points, dst_zero_points,
-                                      attr, dst_type, alowp_kind, aengine);
+                                      dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
   }
 
-  // Deprecated. With bias. Set zero points to tensors for quantization.
+  // Deprecated 2-in-1 compute. With bias. Set zero points to tensors for quantization.
   static void compute(
       const tensor& src,
       const tensor& weights,
@@ -93,13 +393,13 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::undef,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
-    compute_impl</*with_bias=*/true>(src, weights, bias, dst, dst_coeff, sum_coeff,
+    compute_impl</*with_bias=*/true>(src, weights, bias, dst,
                                      src_scales, weights_scales, dst_scales,
                                      zero_point_t(), zero_point_t(),
-                                     attr, dst_type, alowp_kind, aengine);
+                                     dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
   }
 
-  // Deprecated. Without bias. Set zero points to tensors for quantization.
+  // Deprecated 2-in-1 compute. Without bias. Set zero points to tensors for quantization.
   static void compute(
       const tensor& src,
       const tensor& weights,
@@ -114,47 +414,57 @@ struct matmul_forward : public dnnl::matmul,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
     static tensor dummy_bias;
-    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst, dst_coeff,
-                                      sum_coeff, src_scales, weights_scales, dst_scales,
+    compute_impl</*with_bias=*/false>(src, weights, dummy_bias, dst,
+                                      src_scales, weights_scales, dst_scales,
                                       zero_point_t(), zero_point_t(),
-                                      attr, dst_type, alowp_kind, aengine);
+                                      dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
   }
 
-  // Bias is not used if it is empty.
-  template <bool is_dynamic>
+  // Deprecated. Prepare for int8 op with bias. Bias is not used if it is empty.
+  // Static: int8 * int8 -> int8. Dynamic: fp32 * int8 -> fp32
+  template <bool is_dynamic = false>
   static void prepare(matmul_forward_params& param,
                       const tensor& src,
                       const tensor& weights,
                       const tensor& bias,
                       tensor& dst,
-                      const float dst_coeff = 1.0f,
-                      const float sum_coeff = 1.0f,
-                      const scale_t& src_scales = scale_t(),
-                      const scale_t& weights_scales = scale_t(),
-                      const scale_t& dst_scales = scale_t(),
-                      const zero_point_t& src_zero_points = zero_point_t(),
-                      const zero_point_t& dst_zero_points = zero_point_t(),
+                      const float dst_coeff, // default = 1.0f
+                      const float sum_coeff, // for post-op sum, default = 1.0f
+                      const scale_t& src_scales,
+                      const scale_t& weights_scales,
+                      const scale_t& dst_scales,
+                      const zero_point_t& src_zero_points,
+                      const zero_point_t& dst_zero_points,
                       const attr_t& attr = attr_t(),
-                      const data_type dst_type = data_type::undef,
+                      const data_type dst_type = data_type::u8,
                       const lowp_kind alowp_kind = u8s8,
                       const engine& aengine = engine::cpu_engine()) {
-    auto prepare_type = is_dynamic ? type_prepare_dynamic : type_prepare_static;
-    bool with_bias = (!bias.is_empty());
-    do_prepare(param, prepare_type, src, weights, bias, with_bias, dst, dst_coeff, sum_coeff,
-        src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-        attr, dst_type, alowp_kind, aengine);
+    if (is_dynamic) {
+      if (bias.is_empty()) {
+        do_prepare_dynamic_quant</*with_bias=*/false>(
+            param, src, weights, bias, dst, weights_scales,
+            sum_coeff, attr, data_type::f32, aengine);
+      } else {
+        do_prepare_dynamic_quant</*with_bias=*/true>(
+            param, src, weights, bias, dst, weights_scales,
+            sum_coeff, attr, data_type::f32, aengine);
+      }
+    } else {
+      if (bias.is_empty()) {
+        do_prepare_static_quant</*with_bias=*/false>(
+            param, src, weights, bias, dst,
+            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      } else {
+        do_prepare_static_quant</*with_bias=*/true>(
+            param, src, weights, bias, dst,
+            src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+            dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+      }
+    }
   }
 
-  // Bias is not used if it is empty.
-  static void compute(const matmul_forward_params& param,
-                      const tensor& src,
-                      const tensor& weights,
-                      const tensor& bias,
-                      tensor& dst) {
-    bool with_bias = (!bias.is_empty());
-    do_compute(param, type_compute_static, src, weights, bias, with_bias, dst);
-  }
-
+  // Deprecated.
   // Bias is not used if it is empty.
   static void compute_dynamic(
       const matmul_forward_params& param,
@@ -173,16 +483,15 @@ struct matmul_forward : public dnnl::matmul,
       const data_type dst_type = data_type::undef,
       const lowp_kind alowp_kind = u8s8,
       const engine& aengine = engine::cpu_engine()) {
-    bool with_bias = (!bias.is_empty());
-    // Call do_prepare here to calculate scales and zero points.
-    matmul_forward_params param_for_compute;
-    do_prepare(param_for_compute, type_compute_dynamic, src, weights, bias, with_bias, dst, dst_coeff, sum_coeff,
-        src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-        attr, dst_type, alowp_kind, aengine);
-    param_for_compute.pd = param.pd;
-    param_for_compute.primitive = param.primitive;
-    param_for_compute.op_attr = param.op_attr;
-    do_compute(param_for_compute, type_compute_dynamic, src, weights, bias, with_bias, dst);
+    if (bias.is_empty()) {
+      do_compute_dynamic_quant</*with_bias=*/false>(
+          param, src, weights, bias, dst,
+          src_scales, src_zero_points, dst_coeff, aengine);
+    } else {
+      do_compute_dynamic_quant</*with_bias=*/true>(
+          param, src, weights, bias, dst,
+          src_scales, src_zero_points, dst_coeff, aengine);
+    }
   }
 
   static tensor::desc expected_weights_desc(
@@ -192,10 +501,10 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     auto ndims = weights_dims.size();
     auto x_dims = weights_dims;
-    x_dims[ndims-2] = DNNL_RUNTIME_DIM_VAL;
+    x_dims[ndims-2] = 1;
     x_dims[ndims-1] = weights_dims[ndims-2];
     auto y_dims = {x_dims[0], weights_dims[1]};
-    if (ndims == 3) 
+    if (ndims == 3)
         y_dims = {x_dims[0], x_dims[1], weights_dims[2]};
     auto y_dtype = (dtype != data_type::s8) ? dtype : data_type::s32;
 
@@ -213,368 +522,580 @@ struct matmul_forward : public dnnl::matmul,
   }
 
 private:
-enum task_type {
-  type_prepare_static,
-  type_prepare_dynamic,
-  type_compute_static,
-  type_compute_dynamic,
-};
-
+  // For 2-in-1 compute: prepare + compute
+  // Supports fp32, static int8 and dynamic int8
   template <bool with_bias>
- static void compute_impl(const tensor& src,
-                          const tensor& weights,
-                          const tensor& bias,
-                          tensor& dst,
-                          const float dst_coeff = 1.0f,
-                          const float sum_coeff = 1.0f,
-                          const scale_t& src_scales = scale_t(),
-                          const scale_t& weights_scales = scale_t(),
-                          const scale_t& dst_scales = scale_t(),
-                          const zero_point_t& src_zero_points = zero_point_t(),
-                          const zero_point_t& dst_zero_points = zero_point_t(),
-                          const attr_t& attr = attr_t(),
-                          const data_type dst_type = data_type::undef,
-                          const lowp_kind alowp_kind = u8s8,
-                          const engine& aengine = engine::cpu_engine()) {
+  static inline void compute_impl(
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const scale_t& src_scales = scale_t(),
+      const scale_t& weights_scales = scale_t(),
+      const scale_t& dst_scales = scale_t(),
+      const zero_point_t& src_zero_points = zero_point_t(),
+      const zero_point_t& dst_zero_points = zero_point_t(),
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f,
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::undef,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
     matmul_forward_params param;
-    do_prepare(param, type_prepare_static, src, weights, bias, with_bias, dst, dst_coeff, sum_coeff,
-               src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
-               attr, dst_type, alowp_kind, aengine);
-    do_compute(param, type_compute_static, src, weights, bias, with_bias, dst);
+    auto& weights_scales_in =
+        weights.has_scale() ? weights.get_scale() : weights_scales;
+    if (!weights_scales_in.empty()) { // for int8
+      do_prepare_static_quant<with_bias>(
+          param, src, weights, bias, dst,
+          src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+          dst_coeff, sum_coeff, attr, dst_type, alowp_kind, aengine);
+    } else {
+      do_prepare<with_bias>(param, src, weights, bias, dst, dst_coeff, sum_coeff,
+                 attr, dst_type, aengine);
+    }
+    // do_prepare(param, type_prepare_static, src, weights, bias, with_bias, dst, dst_coeff, sum_coeff,
+               // src_scales, weights_scales, dst_scales, src_zero_points, dst_zero_points,
+               // attr, dst_type, alowp_kind, aengine);
+    do_compute<with_bias, /*reorder_src=*/ true, /*reorder_weight=*/ true>(
+        param, src, weights, bias, dst);
   }
 
- static void do_prepare(matmul_forward_params& param,
-                        task_type task,
-                        const tensor& src,
-                        const tensor& weights,
-                        const tensor& bias,
-                        bool with_bias,
-                        tensor& dst,
-                        const float dst_coeff = 1.0f,
-                        const float sum_coeff = 1.0f,
-                        const scale_t& src_scales = scale_t(),
-                        const scale_t& weights_scales = scale_t(),
-                        const scale_t& dst_scales = scale_t(),
-                        const zero_point_t& src_zero_points = zero_point_t(),
-                        const zero_point_t& dst_zero_points = zero_point_t(),
-                        const attr_t& attr = attr_t(),
-                        const data_type dst_type = data_type::undef,
-                        const lowp_kind alowp_kind = u8s8,
-                        const engine& aengine = engine::cpu_engine()) {
-   IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+  // For fp32 op
+  template <bool with_bias>
+  static inline void do_prepare(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f, // for post-op sum
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::f32,
+      const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
 
-   tensor::desc src_desc, weights_desc, bias_desc;
-   attr_t op_attr = attr, src_attr, weights_attr, bias_attr;
-   scale_t dst_scales_in;
-   auto dst_data_type = data_type::f32;
+    tensor::desc src_desc, weights_desc, bias_desc;
+    attr_t op_attr = attr, src_attr, weights_attr, bias_attr;
+    scale_t dst_scales_in;
+    auto dst_data_type = data_type::f32;
 
-   bool is_dynamic = (task == type_prepare_dynamic || task == type_compute_dynamic);
-   const int64_t runtime_bs = DNNL_RUNTIME_DIM_VAL;
-   tensor::dims src_dims = src.get_dims();
-   if (task == type_prepare_dynamic) {
-     src_dims[0] = runtime_bs;
-   }
-   tensor::dims dst_dims = {src_dims[0], weights.get_dim(1)};
-   auto ndims = weights.ndims();
-   if (ndims == 3)
-       dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
+    tensor::dims src_dims = src.get_dims();
+    tensor::dims dst_dims = {src_dims[0], weights.get_dim(1)};
+    auto ndims = weights.ndims();
+    if (ndims == 3)
+      dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
 
-   auto& weights_scales_in =
-       weights.has_scale() ? weights.get_scale() : weights_scales;
-   tensor scales_m, src_zero_point_m, wei_zero_point_m, dst_zero_point_m;
-   if (!weights_scales_in.empty()) {
-     IDEEP_ENFORCE(alowp_kind == u8s8 || alowp_kind == s8s8,
-                   "Unsupported lowp kind");
+    // We intentionally didn't set weight desc to format `any` so DNNL wouldn't
+    // have to determine weight format for us. Because the weight tensor from
+    // pytorch may have a transposed format (say `ba`). However, DNNL would
+    // choose plain format for it by default (`ab` in this case), which would
+    // introduces *an extra reorder* afterwards. Here we keep the weight format
+    // untouched thanks to optimizations for both plain and transposed formats
+    // in DNNL.
+    IDEEP_ENFORCE(weights.get_data_type() == data_type::f32 ||
+                  weights.get_data_type() == data_type::bf16,
+                  "Incorrect data type in weights");
+    dst_data_type = src.get_data_type() == data_type::bf16 ?
+                    data_type::bf16 : data_type::f32;
+    src_desc = src.get_desc().to_type(dst_data_type);
+    weights_desc = weights.get_desc().to_type(dst_data_type);
+    if (with_bias) {
+      IDEEP_ENFORCE(bias.get_data_type() == data_type::f32 ||
+                    bias.get_data_type() == data_type::bf16,
+                    "Incorrect data type in bias");
+      bias_desc = bias.get_desc().to_format_any();
+      auto bias_scales = scale_t(1, 1.0 / dst_coeff);
+      bias_attr = {utils::tensor_scale_mask(1, false), bias_scales};
+    }
 
-     auto src_scales_in =
-         src.has_scale() ? src.get_scale()
-                         : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
-     auto src_data_type = (alowp_kind == u8s8) ? data_type::u8 : data_type::s8;
-     std::vector<int64_t> src_strides = (ndims == 3) ?
-         std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
-         std::vector<int64_t>({src_dims[1], 1});
-     src_desc = is_dynamic ?
-                tensor::desc(src_dims, src_data_type, src_strides) :
-                tensor::desc(src_dims, src_data_type, tag::any);
-     if (src.get_data_type() == data_type::f32) {
-       src_attr = {0, src_scales_in};
-     }
+    if (attr.has_op_kind(kind::sum)) {
+      op_attr = attr_t::fuse_sum(sum_coeff);
+    }
+    int scale_size = 1;
+    op_attr.set_output_scales(utils::op_scale_mask(scale_size),
+                              std::vector<float>(1, dst_coeff));
 
-     int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
-     weights_desc = weights.get_desc();
-     if (weights.get_data_type() == data_type::f32) {
-       weights_attr = {utils::tensor_scale_mask(scale_size, false),
-                       weights_scales_in};
-     }
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-     // determine dst data type
-     if (dst.get_data_type() != data_type::undef) {
-       dst_data_type = dst.get_data_type();
-     } else if (dst_scales.empty() || dst_scales == IDEEP_DEF_SCALE) {
-       dst_data_type = data_type::f32;
-     } else {
-       dst_data_type = data_type::u8;
-     }
-
-     // fill primitive attr
-     scale_t op_scales(scale_size), bias_scales(scale_size);
-     dst_scales_in = (dst_scales.empty() || dst_data_type == data_type::f32)
-                          ? IDEEP_DEF_SCALE
-                          : dst_scales;
-     const zero_point_t default_zero_points = zero_point_t(1);
-     const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
-                                  src_zero_points.empty() ? default_zero_points : src_zero_points;
-     const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
-     const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point() :
-         dst_zero_points.empty() ? default_zero_points : dst_zero_points;
-     const auto dst_zero_point_size = static_cast<dim>(dst_zero_point.size());
-     IDEEP_ENFORCE(src_zero_point_size == 1 && dst_zero_point_size == 1,
-                   "DNNL only support 1-dim zero_point");
-     const auto& wei_zero_point = weights.has_zero_point() ?
-                                  weights.get_zero_point() : default_zero_points;
-     const dim wei_zero_point_size = 1;
-
-     if (attr.has_op_kind(kind::sum)) {
-       float sum_scale =
-           sum_coeff * dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
-       op_attr = attr_t::fuse_sum(sum_scale);
-     }
-
-     auto bias_scales_in =
-         bias.has_scale() ? bias.get_scale() : IDEEP_DEF_SCALE;
-     bias_scales_in = bias_scales_in.size() == 1 ?
-	     std::vector<float>(scale_size, bias_scales_in[0]) : bias_scales_in;
-     bool flag_runtime = is_dynamic;
-     if (flag_runtime) {
-       if (task == type_prepare_dynamic) {
-         op_attr.set_output_scales(utils::op_scale_mask(scale_size), {DNNL_RUNTIME_F32_VAL});
-         op_attr.set_zero_points(DNNL_ARG_SRC, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
-         op_attr.set_zero_points(DNNL_ARG_WEIGHTS, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
-         if (dst_data_type != data_type::f32) {
-           op_attr.set_zero_points(DNNL_ARG_DST, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
-         }
-       } else { // task == type_compute_dynamic
-         tensor::desc scales_desc = {{scale_size}, data_type::f32, {1}};
-         scales_m.init(scales_desc, aengine);
-         auto s = reinterpret_cast<float *>(scales_m.get_data_handle());
-         for (memory::dim i = 0; i < scale_size; ++i) {
-           bias_scales[i] = src_scales_in[0] * weights_scales_in[i] / (dst_coeff * bias_scales_in[i]);
-           s[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
-         }
-         if (src.get_data_type() == data_type::f32) {
-           // Set zero point for reorder (quantization). 1st arg should be DNNL_ARG_DST rather than DNNL_ARG_SRC
-           src_attr.set_zero_points(DNNL_ARG_DST,
-                                    utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
-         }
-
-         tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, {1}};
-         src_zero_point_m.init(src_zero_point_desc, aengine);
-         auto src_z = reinterpret_cast<int32_t *>(src_zero_point_m.get_data_handle());
-         for (memory::dim i = 0; i < src_zero_point_size; ++i)
-           src_z[i] = src_zero_point[i];
-
-         tensor::desc wei_zero_point_desc = {{wei_zero_point_size}, data_type::s32, {1}};
-         wei_zero_point_m.init(wei_zero_point_desc, aengine);
-         auto wei_z = reinterpret_cast<int32_t *>(wei_zero_point_m.get_data_handle());
-         for (memory::dim i = 0; i < wei_zero_point_size; ++i)
-           wei_z[i] = wei_zero_point[i];
-
-         if (dst_data_type != data_type::f32) {
-           tensor::desc dst_zero_point_desc = {{dst_zero_point_size}, data_type::s32, {1}};
-           dst_zero_point_m.init(dst_zero_point_desc, aengine);
-           auto dst_z = reinterpret_cast<int32_t *>(dst_zero_point_m.get_data_handle());
-           for (memory::dim i = 0; i < dst_zero_point_size; ++i)
-             dst_z[i] = dst_zero_point[i];
-         }
-       }
-     } else {
-       for (int i = 0; i < scale_size; i++) {
-         bias_scales[i] = src_scales_in[0] * weights_scales_in[i] / (dst_coeff * bias_scales_in[i]);
-         op_scales[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
-       }
-       op_attr.set_output_scales(utils::op_scale_mask(scale_size), op_scales);
-       op_attr.set_zero_points(DNNL_ARG_SRC,
-                               utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
-       if (src.get_data_type() == data_type::f32) {
-         // Set zero point for reorder (quantization). 1st arg should be DNNL_ARG_DST rather than DNNL_ARG_SRC
-         src_attr.set_zero_points(DNNL_ARG_DST,
-                                  utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
-       }
-       op_attr.set_zero_points(DNNL_ARG_WEIGHTS,
-                               utils::tensor_zp_mask(1), zero_point_t(1,wei_zero_point[0]));
-       if (dst_data_type != data_type::f32) {
-         op_attr.set_zero_points(DNNL_ARG_DST,
-                                 utils::tensor_zp_mask(dst_zero_point.size()), dst_zero_point);
-       }
-     }
-
-     if (with_bias) {
-       tag bia_tag = bias.get_dims().size() == 2 ? tag::ab : tag::abc;
-       bias_desc = {bias.get_dims(), data_type::f32, bia_tag}; // Use f32 instead of s32 to improve accuracy
-       if (bias.get_data_type() != data_type::s32) {
-         auto ndims = bias.get_dims().size();
-         int mask = scale_size > 1 ? 1 << (ndims - 1) : 0;
-         bias_attr = {mask, bias_scales};
-       }
-     }
-   } else {
-     if (src.has_scale()) {
-       auto src_scale = src.get_scale();
-       src_scale[0] = 1.0f / src_scale[0];
-       src_attr = {0, src_scale};
-     }
-
-     // We intentionally didn't set weight desc to format `any` so DNNL wouldn't
-     // have to determine weight format for us. Because the weight tensor from
-     // pytorch may have a transposed format (say `ba`). However, DNNL would
-     // choose plain format for it by default (`ab` in this case), which would
-     // introduces *an extra reorder* afterwards. Here we keep the weight format
-     // untouched thanks to optimizations for both plain and transposed formats
-     // in DNNL.
-     IDEEP_ENFORCE(weights.get_data_type() == data_type::f32 ||
-		   weights.get_data_type() == data_type::bf16,
-                   "Incorrect data type in weights");
-     dst_data_type = src.get_data_type() == data_type::bf16 ?
-                     data_type::bf16 : data_type::f32;
-     src_desc = src.get_desc().to_type(dst_data_type);
-     weights_desc = weights.get_desc().to_type(dst_data_type);
-     if (with_bias) {
-       IDEEP_ENFORCE(bias.get_data_type() == data_type::f32 ||
-		     bias.get_data_type() == data_type::bf16,
-                     "Incorrect data type in bias");
-       bias_desc = bias.get_desc().to_format_any();
-       auto bias_scales = scale_t(1, 1.0 / dst_coeff);
-       bias_attr = {utils::tensor_scale_mask(1, false), bias_scales};
-     }
-
-     if (attr.has_op_kind(kind::sum)) {
-       op_attr = attr_t::fuse_sum(sum_coeff);
-     }
-     int scale_size = 1;
-     op_attr.set_output_scales(utils::op_scale_mask(scale_size),
-		               std::vector<float>(1, dst_coeff));
-   }
-   op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-
-   if (task == type_prepare_static || task == type_prepare_dynamic) {
-     dst_data_type = dst_type == data_type::undef ? dst_data_type : dst_type;
-     std::vector<int64_t> dst_strides = (ndims == 3) ?
-         std::vector<int64_t>({dst_dims[2]* dst_dims[1], dst_dims[1], 1}) :
-         std::vector<int64_t>({dst_dims[1], 1});
-     tensor::desc dst_desc = is_dynamic ?
-         tensor::desc(dst_dims, dst_data_type, dst_strides) :
-         tensor::desc(dst_dims, dst_data_type, tag::any);
-     auto key = utils::create_key(
-         src_desc,
-         weights_desc,
-         bias_desc,
-         dst_desc,
-         op_attr,
-         with_bias,
-         omp_get_max_threads());
-     auto pd = fetch_or_create(key, [&]() {
-       if (with_bias) {
-         return primitive_desc(
-             {src_desc, weights_desc, bias_desc, dst_desc}, op_attr, aengine);
-       } else {
-         return primitive_desc(
-             {src_desc, weights_desc, dst_desc}, op_attr, aengine);
-       }
-     });
-     param.primitive = std::move(super(pd));
-     param.pd = std::move(pd);
-     param.op_attr = std::move(op_attr);
-   }
-
-   param.src_attr = std::move(src_attr);
-   param.weights_attr = std::move(weights_attr);
-   param.bias_attr = std::move(bias_attr);
-   param.dst_scales = std::move(dst_scales_in);
-   if (task == type_compute_dynamic) {
-     param.src_desc = src_desc;
-     param.weights_desc = weights_desc;
-     param.scales_m = std::move(scales_m);
-     param.src_zero_point_m = std::move(src_zero_point_m);
-     param.wei_zero_point_m = std::move(wei_zero_point_m);
-     param.dst_zero_point_m = std::move(dst_zero_point_m);
-   }
+    dst_data_type = dst_type == data_type::undef ? dst_data_type : dst_type;
+    tensor::desc dst_desc = tensor::desc(dst_dims, dst_data_type, tag::any);
+    auto key = utils::create_key(
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        op_attr,
+        with_bias,
+        omp_get_max_threads());
+    auto pd = fetch_or_create(key, [&]() {
+      if (with_bias) {
+        return primitive_desc(
+            {src_desc, weights_desc, bias_desc, dst_desc}, op_attr, aengine);
+      } else {
+        return primitive_desc(
+            {src_desc, weights_desc, dst_desc}, op_attr, aengine);
+      }
+    });
+    param.primitive = std::move(super(pd));
+    param.pd = std::move(pd);
+    param.op_attr = std::move(op_attr);
+    param.src_attr = std::move(src_attr);
+    param.weights_attr = std::move(weights_attr);
+    param.bias_attr = std::move(bias_attr);
  }
 
- static void do_compute(const matmul_forward_params& param,
-                        task_type task,
-                        const tensor& src,
-                        const tensor& weights,
-                        const tensor& bias,
-                        bool with_bias,
-                        tensor& dst) {
-   auto& pd = param.pd;
-   auto& primitive = param.primitive;
-   auto& op_attr = param.op_attr;
-   auto& src_attr = param.src_attr;
-   auto& weights_attr = param.weights_attr;
-   auto& bias_attr = param.bias_attr;
-   auto& dst_scales_in = param.dst_scales;
-   auto& src_desc = param.src_desc;
-   auto& wei_desc = param.weights_desc;
-   auto& scales_m = param.scales_m;
-   auto& src_zero_point_m = param.src_zero_point_m;
-   auto& wei_zero_point_m = param.wei_zero_point_m;
-   auto& dst_zero_point_m = param.dst_zero_point_m;
+  // For static int8 op (int8 * int8 -> int8)
+  template <bool with_bias>
+  static inline void do_prepare_static_quant(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const scale_t& src_scales,
+      const scale_t& weights_scales,
+      const scale_t& dst_scales,
+      const zero_point_t& src_zero_points,
+      const zero_point_t& dst_zero_points,
+      const float dst_coeff = 1.0f,
+      const float sum_coeff = 1.0f, // for post-op sum
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::u8,
+      const lowp_kind alowp_kind = u8s8,
+      const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
 
-   auto expected_src_desc = (task == type_compute_dynamic) ? src_desc : tensor::desc(pd.src_desc());
-   auto expected_wei_desc = (task == type_compute_dynamic) ? wei_desc : tensor::desc(pd.weights_desc());
-   auto expected_dst_desc = (task == type_compute_dynamic) ? dst.get_desc() : pd.dst_desc();
-   auto expected_src = src.reorder_if_differ_in(expected_src_desc, src_attr);
-   auto expected_weights = weights.reorder_if_differ_in(expected_wei_desc, weights_attr);
-   tensor expected_dst;
-   if (dst.is_empty() || dst.get_desc() != expected_dst_desc){
-     // If dst buffer are not given by user or user given dst buffer are not under expected format
-     // We need init a new one
-     expected_dst.init(expected_dst_desc);
-     if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
-       // We need copy the content of given buffer if matmul is fused with sum
-       expected_dst.feed_from(dst);
-     }
-   } else {
-     // The format of given dst buffer is expected
-     expected_dst = dst;
-   }
+    tensor::desc src_desc, weights_desc, bias_desc;
+    attr_t op_attr = attr, src_attr, weights_attr, bias_attr;
+    scale_t dst_scales_in;
+    auto dst_data_type = data_type::u8;
 
-   if (!dst_scales_in.empty() && utils::one_of(dst.get_data_type(), data_type::u8, data_type::s8)) {
-     expected_dst.set_scale(dst_scales_in);
-   }
-   tensor scratchpad(pd.scratchpad_desc());
-   if (with_bias){
-     auto expected_bias = bias.reorder_if_differ_in(pd.bias_desc(), bias_attr);
-     primitive.execute(stream::default_stream(),
-                       {{DNNL_ARG_SRC, expected_src},
-                        {DNNL_ARG_WEIGHTS, expected_weights},
-                        {DNNL_ARG_BIAS, expected_bias},
-                        {DNNL_ARG_DST, expected_dst},
-                        {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
-                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
-                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, dst_zero_point_m},
-                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
-   } else {
-     primitive.execute(stream::default_stream(),
-                       {{DNNL_ARG_SRC, expected_src},
-                        {DNNL_ARG_WEIGHTS, expected_weights},
-                        {DNNL_ARG_DST, expected_dst},
-                        {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
-                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
-                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
-                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, dst_zero_point_m},
-                        {DNNL_ARG_SCRATCHPAD, scratchpad}});
-   }
-   // reorder back to dst's buffer if needed
-   if (dst.is_empty() ||
-         dst.get_desc() == expected_dst.get_desc() ||
-         !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
-     dst =  expected_dst;
-   } else {
-     dst.feed_from(expected_dst);
-   }
+    tensor::dims src_dims = src.get_dims();
+    tensor::dims dst_dims = {src_dims[0], weights.get_dim(1)};
+    auto ndims = weights.ndims();
+    if (ndims == 3) {
+      dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
+    }
+
+    auto& weights_scales_in = weights_scales.empty() ? IDEEP_DEF_SCALE : weights_scales;
+
+    IDEEP_ENFORCE(alowp_kind == u8s8 || alowp_kind == s8s8,
+                  "Unsupported lowp kind");
+
+    auto src_scales_in = src_scales.empty() ? IDEEP_DEF_SCALE : src_scales;
+    auto src_data_type = (alowp_kind == u8s8) ? data_type::u8 : data_type::s8;
+    std::vector<int64_t> src_strides = (ndims == 3) ?
+        std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
+        std::vector<int64_t>({src_dims[1], 1});
+    src_desc = tensor::desc(src_dims, src_data_type, tag::any);
+    if (src.get_data_type() == data_type::f32) {
+      src_attr = {0, src_scales_in};
+    }
+
+    int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
+    weights_desc = weights.get_desc();
+    if (weights.get_data_type() == data_type::f32) {
+      weights_attr = {utils::tensor_scale_mask(scale_size, false),
+                      weights_scales_in};
+    }
+
+    // determine dst data type
+    if (dst.get_data_type() != data_type::undef) {
+      dst_data_type = dst.get_data_type();
+    } else if (dst_scales.empty() || dst_scales == IDEEP_DEF_SCALE) {
+      dst_data_type = data_type::f32;
+    } else {
+      dst_data_type = data_type::u8;
+    }
+
+    // fill primitive attr
+    scale_t op_scales(scale_size), bias_scales(scale_size);
+    dst_scales_in = (dst_scales.empty() || dst_data_type == data_type::f32)
+                        ? IDEEP_DEF_SCALE
+                        : dst_scales;
+    const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
+                                 src_zero_points.empty() ? IDEEP_DEF_ZP : src_zero_points;
+    const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
+    const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point() :
+        dst_zero_points.empty() ? IDEEP_DEF_ZP : dst_zero_points;
+    const auto dst_zero_point_size = static_cast<dim>(dst_zero_point.size());
+    IDEEP_ENFORCE(src_zero_point_size == 1 && dst_zero_point_size == 1,
+                  "DNNL only support 1-dim zero_point");
+    const auto& wei_zero_point = weights.has_zero_point() ?
+                                 weights.get_zero_point() : IDEEP_DEF_ZP;
+    const dim wei_zero_point_size = 1;
+
+    if (attr.has_op_kind(kind::sum)) {
+      float sum_scale =
+          sum_coeff * dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+      op_attr = attr_t::fuse_sum(sum_scale);
+    }
+
+    auto bias_scales_in =
+        bias.has_scale() ? bias.get_scale() : IDEEP_DEF_SCALE;
+    bias_scales_in = bias_scales_in.size() == 1 ?
+        std::vector<float>(scale_size, bias_scales_in[0]) : bias_scales_in;
+    for (int i = 0; i < scale_size; i++) {
+      bias_scales[i] = src_scales_in[0] * weights_scales_in[i] / (dst_coeff * bias_scales_in[i]);
+      op_scales[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
+    }
+    op_attr.set_output_scales(utils::op_scale_mask(scale_size), op_scales);
+    op_attr.set_zero_points(DNNL_ARG_SRC,
+                            utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
+    if (src.get_data_type() == data_type::f32) {
+      // Set zero point for src reorder (fp32 -> int8).
+      // First arg should be DNNL_ARG_DST rather than DNNL_ARG_SRC
+      src_attr.set_zero_points(DNNL_ARG_DST,
+                               utils::tensor_zp_mask(src_zero_point.size()),
+                               src_zero_point);
+    }
+    op_attr.set_zero_points(DNNL_ARG_WEIGHTS,
+                            utils::tensor_zp_mask(1), zero_point_t(1,wei_zero_point[0]));
+    if (dst_data_type != data_type::f32) {
+      op_attr.set_zero_points(DNNL_ARG_DST,
+                              utils::tensor_zp_mask(dst_zero_point.size()), dst_zero_point);
+    }
+
+    if (with_bias) {
+      tag bia_tag = bias.get_dims().size() == 2 ? tag::ab : tag::abc;
+      bias_desc = {bias.get_dims(), data_type::f32, bia_tag}; // Use f32 instead of s32 to improve accuracy
+      if (bias.get_data_type() != data_type::s32) {
+        auto ndims = bias.get_dims().size();
+        int mask = scale_size > 1 ? 1 << (ndims - 1) : 0;
+        bias_attr = {mask, bias_scales};
+      }
+    }
+
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    dst_data_type = dst_type == data_type::undef ? dst_data_type : dst_type;
+    tensor::desc dst_desc = tensor::desc(dst_dims, dst_data_type, tag::any);
+    auto key = utils::create_key(
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        op_attr,
+        with_bias,
+        omp_get_max_threads());
+    auto pd = fetch_or_create(key, [&]() {
+      if (with_bias) {
+        return primitive_desc(
+            {src_desc, weights_desc, bias_desc, dst_desc}, op_attr, aengine);
+      } else {
+        return primitive_desc(
+            {src_desc, weights_desc, dst_desc}, op_attr, aengine);
+      }
+    });
+    param.primitive = std::move(super(pd));
+    param.pd = std::move(pd);
+    param.op_attr = std::move(op_attr);
+
+    param.src_attr = std::move(src_attr);
+    param.weights_attr = std::move(weights_attr);
+    param.bias_attr = std::move(bias_attr);
+ }
+
+  // For dynamic int8 op (fp32 * int8 -> fp32)
+  template <bool with_bias>
+  static inline void do_prepare_dynamic_quant(
+      matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const scale_t& weights_scales,
+      const float sum_coeff = 1.0f, // for post-op sum
+      const attr_t& attr = attr_t(),
+      const data_type dst_type = data_type::f32,
+      const engine& aengine = engine::cpu_engine()) {
+    /* This function does the following things:
+     * - Determine expected descs of src/weight/dst
+     * - Use runtime values for op attributes
+     * - Create matmul primitive desc and primitive
+     * - Create reorder primitive for src (fp32 -> int8)
+     */
+
+    IDEEP_ENFORCE(src.ndims() == weights.ndims(), "Invalid dims in src or weights");
+    if (!param.dq_param_ptr) {
+      param.dq_param_ptr = std::make_shared<matmul_forward_dyn_quant_params>();
+    }
+    IDEEP_ENFORCE(param.dq_param_ptr, "Failed to allocate memory for parameters");
+
+    tensor::desc &src_desc = param.dq_param_ptr->src_desc;
+    attr_t op_attr = attr, src_attr;
+
+    tensor::dims src_dims = src.get_dims();
+    tensor::dims dst_dims = {src_dims[0], weights.get_dim(1)};
+    auto ndims = weights.ndims();
+    if (ndims == 3)
+        dst_dims = {src_dims[0], src.get_dim(1), weights.get_dim(2)};
+
+    auto& weights_scales_in =
+        weights.has_scale() ? weights.get_scale() : weights_scales;
+
+    auto src_data_type = data_type::u8;
+    std::vector<int64_t> src_strides = (ndims == 3) ?
+        std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
+        std::vector<int64_t>({src_dims[1], 1});
+    src_desc = tensor::desc(src_dims, src_data_type, src_strides);
+
+    // Prepare tensor of weight zero point
+    static auto wei_zero_point = zero_point_t(1);
+    const dim wei_zero_point_size = 1;
+    tensor::desc wei_zero_point_desc = {{wei_zero_point_size}, data_type::s32, {1}};
+    tensor wei_zero_point_m(wei_zero_point_desc, reinterpret_cast<int*>(wei_zero_point.data()), aengine);
+
+    // fill primitive attr
+    if (attr.has_op_kind(kind::sum)) {
+      op_attr = attr_t::fuse_sum(sum_coeff);
+    }
+    op_attr.set_output_scales(utils::op_scale_mask(1/* scale_size */), {DNNL_RUNTIME_F32_VAL});
+    op_attr.set_zero_points(DNNL_ARG_SRC, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    op_attr.set_zero_points(DNNL_ARG_WEIGHTS, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+    op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    // Src attr for reorder
+    src_attr.set_output_scales(utils::op_scale_mask(1), {DNNL_RUNTIME_F32_VAL});
+    src_attr.set_zero_points(DNNL_ARG_DST, utils::tensor_zp_mask(1), {DNNL_RUNTIME_S32_VAL});
+
+    // Dst desc
+    std::vector<int64_t> dst_strides = (ndims == 3) ?
+        std::vector<int64_t>({dst_dims[2]* dst_dims[1], dst_dims[1], 1}) :
+        std::vector<int64_t>({dst_dims[1], 1});
+    tensor::desc dst_desc = tensor::desc(dst_dims, dst_type, dst_strides);
+
+    // Create pd and primitive
+    param.pd = primitive_desc({src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
+    param.primitive = super(param.pd);
+    param.op_attr = std::move(op_attr);
+
+    // Create src reorder primitive with runtime scales/zero point
+    auto src_reorder_pd = dnnl::reorder::primitive_desc(aengine, src.get_desc(), aengine, src_desc, src_attr);
+    param.dq_param_ptr->src_reorder = dnnl::reorder(src_reorder_pd);
+
+    param.dq_param_ptr->weight_scales = std::move(weights_scales_in);
+    param.dq_param_ptr->wei_zero_point_m = std::move(wei_zero_point_m);
+ }
+
+  // For fp32 and static int8 op (int8 * int8 -> int8)
+  // Set reorder flags to false if you are sure the memory layout aligns
+  // with primitive descriptor. Otherwise, checks are made and reorder
+  // may be needed.
+  template <bool with_bias, bool reorder_src, bool reorder_weight>
+  static inline void do_compute(
+      const matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst) {
+    auto& pd = param.pd;
+    auto& primitive = param.primitive;
+    auto& op_attr = param.op_attr;
+    auto& src_attr = param.src_attr;
+    auto& weights_attr = param.weights_attr;
+    auto& bias_attr = param.bias_attr;
+
+    auto expected_src_desc = pd.src_desc();
+    auto expected_wei_desc = pd.weights_desc();
+    auto expected_dst_desc = pd.dst_desc();
+
+    auto& expected_src = reorder_src ?
+                         src.reorder_if_differ_in(expected_src_desc, src_attr) :
+                         src;
+    auto& expected_weights = reorder_weight ?
+                             weights.reorder_if_differ_in(expected_wei_desc, weights_attr) :
+                             weights;
+    tensor scratchpad(pd.scratchpad_desc());
+
+    if (reorder_src) {
+      tensor expected_dst;
+      if (dst.is_empty() || dst.get_desc() != expected_dst_desc){
+        // If dst buffer are not given by user or user given dst buffer are not under expected format
+        // We need init a new one
+        expected_dst.init(expected_dst_desc);
+        if (!dst.is_empty() && op_attr.has_op_kind(kind::sum)) {
+          // We need copy the content of given buffer if matmul is fused with sum
+          expected_dst.feed_from(dst);
+        }
+      } else {
+        // The format of given dst buffer is expected
+        expected_dst = dst;
+      }
+      if (with_bias){
+        auto& expected_bias = reorder_weight ?
+                             bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
+                             bias;
+        primitive.execute(stream::default_stream(),
+                          {{DNNL_ARG_SRC, expected_src},
+                           {DNNL_ARG_WEIGHTS, expected_weights},
+                           {DNNL_ARG_BIAS, expected_bias},
+                           {DNNL_ARG_DST, expected_dst},
+                           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      } else {
+        primitive.execute(stream::default_stream(),
+                          {{DNNL_ARG_SRC, expected_src},
+                           {DNNL_ARG_WEIGHTS, expected_weights},
+                           {DNNL_ARG_DST, expected_dst},
+                           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      }
+      // reorder back to dst's buffer if needed
+      if (dst.is_empty() ||
+            dst.get_desc() == expected_dst.get_desc() ||
+            !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
+        dst =  expected_dst;
+      } else {
+        dst.feed_from(expected_dst);
+      }
+    } else {
+      tensor& expected_dst = dst;
+      if (with_bias){
+        auto& expected_bias = reorder_weight ?
+                             bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
+                             bias;
+        primitive.execute(stream::default_stream(),
+                          {{DNNL_ARG_SRC, expected_src},
+                           {DNNL_ARG_WEIGHTS, expected_weights},
+                           {DNNL_ARG_BIAS, expected_bias},
+                           {DNNL_ARG_DST, expected_dst},
+                           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      } else {
+        primitive.execute(stream::default_stream(),
+                          {{DNNL_ARG_SRC, expected_src},
+                           {DNNL_ARG_WEIGHTS, expected_weights},
+                           {DNNL_ARG_DST, expected_dst},
+                           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      }
+    }
+
+/*     if (with_bias){
+      auto& expected_bias = reorder_weight ?
+                           bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
+                           bias;
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_BIAS, expected_bias},
+                         {DNNL_ARG_DST, expected_dst},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    } else {
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_DST, expected_dst},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    }
+    if (reorder_src) {
+      // reorder back to dst's buffer if needed
+      if (dst.is_empty() ||
+            dst.get_desc() == expected_dst.get_desc() ||
+            !dst.get_desc().has_same_shape_as(expected_dst.get_desc())){
+        dst =  expected_dst;
+      } else {
+        dst.feed_from(expected_dst);
+      }
+    } */
+  }
+
+  // For dynamic int8 op (fp32 * int8 -> fp32)
+  // Set reorder flags to false if you are sure the memory layout aligns
+  // with primitive descriptor. Otherwise, checks are made and reorder
+  // may be needed.
+  template <bool with_bias, bool reorder_weight = true>
+  static inline void do_compute_dynamic_quant(
+      const matmul_forward_params& param,
+      const tensor& src,
+      const tensor& weights,
+      const tensor& bias,
+      tensor& dst,
+      const scale_t& src_scales,
+      const zero_point_t& src_zero_points,
+      const float dst_coeff = 1.0f,
+      const engine& aengine = engine::cpu_engine()) {
+    /* Compute for dynamic quantized linear. This function does the following things:
+     * - Get matmul primitive from param
+     * - Get reorder primitive for src from param.dq_param_ptr
+     * - Prepare tensors of output scales and zero points.
+     * - Compute by executing matmul primitive
+     */
+
+    // Get primitive, etc. from param
+    IDEEP_ENFORCE(param.dq_param_ptr, "Parameters for dynamic quantization not found");
+    auto& pd = param.pd;
+    auto& primitive = param.primitive;
+    auto& op_attr = param.op_attr;
+    auto& weights_attr = param.weights_attr;
+    auto& weights_scales_in = param.dq_param_ptr->weight_scales;
+    auto& expected_src_desc = param.dq_param_ptr->src_desc;
+    auto& wei_zero_point_m = param.dq_param_ptr->wei_zero_point_m;
+    auto &src_reorder = param.dq_param_ptr->src_reorder;
+    auto expected_dst_desc = dst.get_desc();
+
+    // Prepare tensor of output scales
+    int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
+    auto src_scales_in =
+        src.has_scale() ? src.get_scale()
+                        : (src_scales.empty() ? IDEEP_DEF_SCALE : src_scales);
+    auto& dst_scales_in = IDEEP_DEF_SCALE;
+
+    tensor::desc scales_desc = {{scale_size}, data_type::f32, {1}};
+    tensor scales_m(scales_desc, aengine);
+    auto s = reinterpret_cast<float *>(scales_m.get_data_handle());
+    for (memory::dim i = 0; i < scale_size; ++i) {
+      s[i] = dst_coeff * dst_scales_in[0] / (src_scales_in[0] * weights_scales_in[i]);
+    }
+
+    // Prepare tensor of src scales
+    auto src_scale_size = src_scales_in.size();
+    tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, {1}};
+    tensor src_scales_m(src_scales_desc, reinterpret_cast<float*>(src_scales_in.data()), aengine);
+
+    // Prepare tensor of src zero point
+    static const zero_point_t default_zero_points = zero_point_t(1);
+    auto src_zero_point = src.has_zero_point() ? src.get_zero_point() :
+                              src_zero_points.empty() ? default_zero_points : src_zero_points;
+    const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
+    IDEEP_ENFORCE(src_zero_point_size == 1,
+                  "DNNL only support 1-dim zero_point");
+    tensor::desc src_zero_point_desc = {{src_zero_point_size}, data_type::s32, {1}};
+    tensor src_zero_point_m(src_zero_point_desc, reinterpret_cast<int32_t*>(src_zero_point.data()), aengine);
+
+    // Reroder src (f32 -> u8)
+    tensor expected_src(expected_src_desc);
+    src_reorder.execute(stream::default_stream(),
+                        {{DNNL_ARG_FROM, src},
+                         {DNNL_ARG_TO, expected_src},
+                         {DNNL_ARG_ATTR_OUTPUT_SCALES, src_scales_m},
+                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, src_zero_point_m}});
+
+    // Check weight desc
+    auto& expected_weights = reorder_weight ?
+                             weights.reorder_if_differ_in(pd.weights_desc(), weights_attr) :
+                             weights;
+    tensor &expected_dst = dst;
+
+    tensor scratchpad(pd.scratchpad_desc());
+    if (with_bias){
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, bias},
+                         {DNNL_ARG_DST, expected_dst},
+                         {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
+                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    } else {
+      primitive.execute(stream::default_stream(),
+                        {{DNNL_ARG_SRC, expected_src},
+                         {DNNL_ARG_WEIGHTS, expected_weights},
+                         {DNNL_ARG_DST, expected_dst},
+                         {DNNL_ARG_ATTR_OUTPUT_SCALES, scales_m},
+                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m},
+                         {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, wei_zero_point_m},
+                         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+    }
   }
 
 };

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -17,10 +17,10 @@ struct matmul_forward_dyn_quant_params {
       tensor&& wei_zero_point_m,
       tensor::desc&& src_desc,
       dnnl::reorder::primitive&& src_reorder)
-      : _weight_scales(weight_scales),
-        _wei_zero_point_m(wei_zero_point_m),
-        _src_desc(src_desc),
-        _src_reorder(src_reorder) {}
+      : _weight_scales(std::move(weight_scales)),
+        _wei_zero_point_m(std::move(wei_zero_point_m)),
+        _src_desc(std::move(src_desc)),
+        _src_reorder(std::move(src_reorder)) {}
 };
 
 // Common parameters for computation
@@ -41,11 +41,11 @@ struct matmul_forward_params {
       attr_t&& src_attr,
       attr_t&& weights_attr,
       attr_t&& bias_attr)
-      : _pd(pd),
-        _op_attr(op_attr),
-        _src_attr(src_attr),
-        _weights_attr(weights_attr),
-        _bias_attr(bias_attr) {
+      : _pd(std::move(pd)),
+        _op_attr(std::move(op_attr)),
+        _src_attr(std::move(src_attr)),
+        _weights_attr(std::move(weights_attr)),
+        _bias_attr(std::move(bias_attr)) {
     _primitive = dnnl::matmul(_pd);
   }
 };

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -542,9 +542,8 @@ struct matmul_forward : public dnnl::matmul,
     tensor::desc y_desc(y_dims, y_dtype, ndims == 2 ? tag::ab : tag::abc);
     tensor::desc weights_desc(weights_dims , dtype, tag::any);
     attr_t attr;
-    attr.set_output_scales(/* mask */ (1 << 1), {DNNL_RUNTIME_F32_VAL});
+    // If runtime src zero point is not set here, slow ref kernel will be used for quantization
     attr.set_zero_points(DNNL_ARG_SRC, /* mask */ 0, {DNNL_RUNTIME_S32_VAL});
-    attr.set_zero_points(DNNL_ARG_DST, /* mask */ 0, {DNNL_RUNTIME_S32_VAL});
     auto pd = primitive_desc({x_desc, weights_desc, y_desc}, attr, aengine);
     return pd.weights_desc();
   }


### PR DESCRIPTION
## Description
This PR refactors ideep APIs for matmul and inner_product.
New design separates paths for fp32, static int8 and dynamic int8. Old APIs remain for compatibility, but their implementations are changed using new implementations.
Quantization of inner_product is removed. All quantized `*mm` operations go to matmul.

## Changes
There are three types of public API:
- 2-in-1 compute: Take everything in and output the result. 2 for fp32, 2 for int8.
- Prepare: Prepare parameters and store prepared data in a struct, including primitive and its descriptor. 2 for fp32, 2 for int8.
- Compute with prepared data: Take prepared data and other necessary inputs in and output the results. This can be used as fast paths as overhead of preparation is removed. 2 for fp32 and static int8, 2 for dynamic int8.

Separate implementations for fp32/static int8/dynamic int8:
- 3 `do_prepare` functions for fp32/static int8/dynamic int8 respectively
- 2 `do_compute` functions, 1 for fp32 and static int8, the other for dynamic int8. They take in prepared data for computation.
- 1 `compute_impl` function for 2-in-1 computation path. It calls `do_prepare` and `do_compute`.

Structs to store prepared data
- 1 struct for common data (needed by fp32/int8)
- 1 struct for dynamic quantization
- No additional param is needed for static int8 for matmul

The common data struct holds a `shared_ptr` of the quantization data struct. The pointer is not used and the quantization struct is not allocated for fp32 path.

## Validation
PyTorch UT passed:
- test_quantization.py
- test_mkldnn.py
- test_ops.py