### PR TITLE
API refactor for deconv

### DIFF
--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -968,8 +968,8 @@ private:
       }
       if (with_bias){
         auto& expected_bias = reorder_weight ?
-                             bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                             bias;
+                              bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
+                              bias;
         primitive.execute(stream::default_stream(),
                           {{DNNL_ARG_SRC, expected_src},
                            {DNNL_ARG_WEIGHTS, expected_weights},
@@ -995,8 +995,8 @@ private:
       tensor& expected_dst = dst;
       if (with_bias){
         auto& expected_bias = reorder_weight ?
-                             bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
-                             bias;
+                              bias.reorder_if_differ_in(pd.bias_desc(), bias_attr) :
+                              bias;
         primitive.execute(stream::default_stream(),
                           {{DNNL_ARG_SRC, expected_src},
                            {DNNL_ARG_WEIGHTS, expected_weights},

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -674,7 +674,23 @@ class tensor : public memory {
       return *this;
     } else {
       tensor dst{expected_desc};
-      this->reorder_to(dst, aattr);
+      // Keep scale and zero point
+      if (has_scale()) {
+        dst.set_scale(get_scale());
+      }
+      if (has_zero_point()) {
+        dst.set_zero_point(get_zero_point());
+      }
+      // Try to reorder and catch possible runtime errors.
+      // If error occurs, it is reordered to plain format then to the desired format
+      try {
+        reorder_to(dst, aattr);
+      } catch (...) {
+        // A common error is 'could not create a reorder primitive descriptor'
+        // We won't distinguish between specific errors
+        ideep::tensor&& plain_weight = to_public(nullptr, get_data_type());
+        plain_weight.reorder_to(dst, aattr);
+      }
       return dst;
     }
   }


### PR DESCRIPTION
## Description
This PR mainly refactors APIs of deconv.
It separates fp32 and int8 paths and provide fast paths of computation with prepared parameters.

## Changes
- Add new APIs for deconv. Some deprecated APIs are removed since they are not used.
- Add `reorder_src` and `reorder_weight` flags to inner-product `compute` functions. Remove unnecessary codes.
- Modified `tensor::reorder_if_differ_in()` to keep scale and zero point and handle runtime errors from oneDNN.

