### PR TITLE
downgrade llga and related fusion for latest stock pytorch

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -252,7 +252,8 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_hardsigmoid() {
+// Disable this fusion until newer oneDNN support it
+/*  static attr_t fuse_hardsigmoid() {
     constexpr float scale = 1.0f;
     constexpr float alpha = 1.0f / 6.0f;
     constexpr float beta = 1.0f / 2.0f;
@@ -263,7 +264,7 @@ struct attr_t : public dnnl::primitive_attr {
     attr.set_post_ops(po);
     return attr;
   }
-
+*/
   static attr_t fuse_binary(algorithm alg, memory::desc src_desc) {
     attr_t attr;
     post_ops po;


### PR DESCRIPTION
Downgrade llga to 888a87a which is the version current stock pytorch used through pytorch_dnnl branch. Also disable fuse_hardsigmoid() as requiring newer oneDNN, it should be re-enabled in future with newer llga/oneDNN.