### PR TITLE
Fix PyTorch CI failures (conv/matmul)

### DIFF
--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1839,11 +1839,11 @@ private:
       auto expected_dst_desc = param.pd.dst_desc();
       tensor expected_dst;
       if (dst.is_empty() || dst.get_desc() != expected_dst_desc){
-        // If dst buffer are not given by user or user given dst buffer are not under expected format
-        // We need init a new one
+        // If dst buffer is not given by user or the given buffer is not in expected format,
+        // We need to init a new one
         expected_dst.init(expected_dst_desc);
         if (!dst.is_empty() && param.op_attr.has_op_kind(kind::sum)) {
-          // We need copy the content of given buffer if matmul is fused with sum
+          // We need to copy the content of given buffer if the op is fused with sum
           expected_dst.feed_from(dst);
         }
       } else {

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -1304,7 +1304,7 @@ struct matmul_forward : public dnnl::matmul,
     }
 
     // Prepare tensor of src scales
-    auto src_scale_size = src_scales_in.size();
+    int src_scale_size = src_scales_in.size();
     tensor::desc src_scales_desc = {{src_scale_size}, data_type::f32, {scale_zp_stride}};
     tensor src_scales_m(src_scales_desc, reinterpret_cast<float*>(src_scales_in.data()), aengine);
 


### PR DESCRIPTION
- Fix bug in conv when dst tensor does not have the expected shape
  - Reinit needed. The logic is now the same as in matmul.
- Use `int` data type to represent scales vector size to avoid narrowing conversion in matmul.hpp
  - `auto` leads to `int64_t`, which may cause narrowing conversion in later operations. It now aligns with conv.


@jgong5 @XiaobingSuper @Guobing-Chen Please review. Thanks.