### PR TITLE
Bug fix found by Caffe2 UT

### DIFF
--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -2042,6 +2042,9 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
     // diff_src has been init in FW side, but has diff desc with
     // expected_diff_src.
     if (diff_src.get_desc() != expected_diff_src_desc) {
+      if (!diff_src.get_desc().has_same_shape_as(expected_diff_src_desc)) {
+        diff_src.reinit_if_possible(expected_diff_src_desc);
+      }
       diff_src.feed_from(expected_diff_src);
     }
   }
@@ -2247,6 +2250,9 @@ struct convolution_backward_weights
     // diff_weights has been init in FW side, but has diff desc with
     // expected_diff_weights.
     if (diff_weights.get_desc() != expected_diff_weights_desc) {
+      if (!diff_weights.get_desc().has_same_shape_as(expected_diff_weights_desc)) {
+        diff_weights.reinit_if_possible(expected_diff_weights_desc);
+      }
       diff_weights.feed_from(expected_diff_weights);
     }
   }

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -163,93 +163,27 @@ class tensor : public memory {
       return true;
     }
 
-    inline bool is_nhwc(bool caffe2_use = false) const {
-      if (!is_plain() || data.ndims != 4)
-        return false;
-      const auto& dims = data.dims;
-      const auto& strides = blocking_strides();
-      // For caffe2 use, N111 is regarded as channels last.
-      if (caffe2_use) {
-        const auto n = 0, c = 1, h = 2, w = 3;
-        return strides[n] == dims[h] * dims[w] * dims[c] &&
-            strides[h] == dims[w] * dims[c] && strides[w] == dims[c] &&
-            strides[c] == 1;
-      }
-
-      // From c10/core/MemoryFormat.h:117
-      int64_t min = 0;
-      // special case for trivial C dimension. default to NCHW
-      if (strides[1] == 0) {
-        return false;
-      }
-      // loop strides indices
-      for (auto& d : {1, 3, 2, 0}) {
-        if (dims[d] == 0) {
-          return false;
-        }
-        if (strides[d] < min) {
-          return false;
-        }
-        // Fallback to NCHW as default layout for ambiguous cases
-        // This is the flaw of implicit memory_format from strides.
-        // N111 tensor with identical strides for size 1 dimension;
-        // Two cases could lead us here:
-        // a. N111 contiguous Tensor ([N,1,1,1]@[1,1,1,1])
-        // b. N11W contiguous Tensor sliced on the W-dimension.
-        // ([N,1,1,1]@[W,W,W,W])
-        if (d == 0 && min == strides[1]) {
-          return false;
-        }
-        // This is necessary to:
-        // 1. distinguish the memory_format of N1H1;
-        //     [H, 1, 1, 1] channels_last stride
-        //     [H, H, 1, 1] contiguous stride
-        // 2. permutation of 1C1W:
-        //     [1, C, 1, H]@[HC, H, H, 1] transpose(1, 3)
-        //     [1, H, 1, C]@[HC, 1, H, H] shouldn't be identified as
-        //     channels_last
-        min = strides[d];
-        if (dims[d] > 1) {
-          min *= dims[d];
-        }
-      }
-      return true;
+    inline bool is_nhwc() const {
+      if (!is_plain() || data.ndims != 4) return false;
+      const auto &dims = data.dims;
+      const auto &strides = blocking_strides();
+      const auto n = 0, c = 1, h = 2, w = 3;
+      return strides[n] == dims[h] * dims[w] * dims[c]
+          && strides[h] == dims[w] * dims[c]
+          && strides[w] == dims[c]
+          && strides[c] == 1;
     };
 
-    inline bool is_ndhwc(bool caffe2_use = false) const {
-      if (!is_plain() || data.ndims != 5)
-        return false;
-      const auto& dims = data.dims;
-      const auto& strides = blocking_strides();
-      // For caffe2 use
-      if (caffe2_use) {
-        const auto n = 0, c = 1, d = 2, h = 3, w = 4;
-        return strides[n] == dims[d] * dims[h] * dims[w] * dims[c] &&
-            strides[d] == dims[h] * dims[w] * dims[c] &&
-            strides[h] == dims[w] * dims[c] && strides[w] == dims[c] &&
-            strides[c] == 1;
-      }
-      // From c10/core/MemoryFormat.h:158
-      int64_t min = 0;
-      if (strides[1] == 0) {
-        return false;
-      }
-      for (auto& d : {1, 4, 3, 2, 0}) {
-        if (dims[d] == 0) {
-          return false;
-        }
-        if (strides[d] < min) {
-          return false;
-        }
-        if (d == 0 && min == strides[1]) {
-          return false;
-        }
-        min = strides[d];
-        if (dims[d] > 1) {
-          min *= dims[d];
-        }
-      }
-      return true;
+    inline bool is_ndhwc() const {
+      if (!is_plain() || data.ndims != 5) return false;
+      const auto &dims = data.dims;
+      const auto &strides = blocking_strides();
+      const auto n = 0, c = 1, d =2, h = 3, w = 4;
+      return strides[n] == dims[d] * dims[h] * dims[w] * dims[c]
+          && strides[d] == dims[h] * dims[w] * dims[c]
+          && strides[h] == dims[w] * dims[c]
+          && strides[w] == dims[c]
+          && strides[c] == 1;
     }
 
     inline bool is_nchw() const {

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -163,6 +163,9 @@ class tensor : public memory {
       return true;
     }
 
+    // The logic of this function differs from PyTorch
+    // It may cause error in edge cases.
+    // Avoid using it to determine memory layout in PyTorch.
     inline bool is_nhwc() const {
       if (!is_plain() || data.ndims != 4) return false;
       const auto &dims = data.dims;
@@ -174,6 +177,9 @@ class tensor : public memory {
           && strides[c] == 1;
     };
 
+    // The logic of this function differs from PyTorch
+    // It may cause error in edge cases.
+    // Avoid using it to determine memory layout in PyTorch.
     inline bool is_ndhwc() const {
       if (!is_plain() || data.ndims != 5) return false;
       const auto &dims = data.dims;


### PR DESCRIPTION
**Changes**
- Revert changes of channels last check.
  - These changes were once added to pytorch_dnnl branch. During convergence, we imported them. Now they are not needed (according to @yanbing-j ) and they are causing UT failures. So, we revert them.
- Reinit output tensor for conv_backward_data/_weights if the output shape is not correct
  - We solved a similar issue in https://github.com/intel/ideep/pull/117. That was for forward path. Same issue found for backward paths. As we have discussed before, we first ensure correctness and keep the original behavior. The buffer sharing issue will be addressed later.

**Validation**
PyTorch: test_quantization.py, test_mkldnn*, test_ops.py
Caffe2: test cases in caffe2/python/ideep
IPEX: UTs

---

Please review. Thanks! @jgong5 @XiaobingSuper @Guobing-Chen