### PR TITLE
Add fp16 for conv and ip

### DIFF
--- a/include/ideep/abstract_types.hpp
+++ b/include/ideep/abstract_types.hpp
@@ -74,6 +74,12 @@ static bool has_bf16_type_support() {
   return support_bf16;
 }
 
+static bool has_fp16_type_support() {
+  static bool support_fp16 =
+      dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx512_core_fp16;
+  return support_fp16;
+}
+
 /// cpu execution engine only.
 struct engine : public dnnl::engine {
   friend class tensor;

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -248,18 +248,20 @@ struct conv_deconv_utils {
     dil_compatible = utils::get_compatible_dilates(dilates);
 
     IDEEP_ENFORCE(utils::one_of(weight_grouped.get_data_type(),
-                                data_type::f32, data_type::bf16),
+                                data_type::f32, data_type::bf16, data_type::f16),
                   "Incorrect data type in weights");
 
     // align weights data type with src
-    dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
-                                                            : data_type::f32;
+    dst_data_type = src.get_data_type() == data_type::bf16
+        ? data_type::bf16
+        : ((src.get_data_type() == data_type::f16) ? data_type::f16
+                                                   : data_type::f32);
     src_desc = src.get_desc().to_type(dst_data_type);
     weights_desc = weight_grouped.get_desc().to_type(dst_data_type);
 
     if (with_bias) {
       IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
-                                  data_type::f32, data_type::bf16),
+                                  data_type::f32, data_type::bf16, data_type::f16),
                     "Incorrect data type in bias");
       bias_desc = bias.get_desc();
     }
@@ -1385,7 +1387,8 @@ struct convolution_forward
           + (padding_l[d-2] + padding_r[d-2])) / strides[d-2] + 1;
       y_dims.push_back(out_size);
     }
-    x_dtype = dtype == data_type::bf16 ? dtype : x_dtype;
+    x_dtype =
+        (dtype == data_type::bf16 || dtype == data_type::f16) ? dtype : x_dtype;
     auto y_dtype = dtype != data_type::s8 ? dtype : data_type::s32;
     tensor::desc src_desc(x_dims, x_dtype);
     tensor::desc dst_desc(y_dims, y_dtype);
@@ -1947,7 +1950,7 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
       }
     }
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
-    // align weight data type with diff_dst for bf16
+    // align weight data type with diff_dst for bf16 and f16
     auto weights_desc =
         weights_.get_desc().to_format_any().to_type(diff_dst.get_data_type());
 
@@ -2000,7 +2003,7 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
     auto format_tag = is_nhwc ? tag::nhwc : (is_ndhwc ? tag::ndhwc : tag::any);
     bool is_channels_last = is_nhwc || is_ndhwc;
     auto diff_dst_desc = diff_dst.get_desc().to_format(format_tag);
-    // align weight data type with diff_dst for bf16
+    // align weight data type with diff_dst for bf16 and f16
     auto weights_desc =
         weights_.get_desc().to_format_any().to_type(diff_dst.get_data_type());
 

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -561,11 +561,15 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
                       const engine& aengine = engine::cpu_engine()) {
     auto weights_ = weights;
     if (diff_dst.get_data_type() == data_type::bf16) {
-      weights_.init(weights.get_desc().to_type(data_type::bf16));
-      weights_.reorder_from(weights);
+      if (weights_.get_data_type() != data_type::bf16) {
+        weights_.init(weights.get_desc().to_type(data_type::bf16));
+        weights_.reorder_from(weights);
+      }
     } else if (diff_dst.get_data_type() == data_type::f16) {
-      weights_.init(weights.get_desc().to_type(data_type::f16));
-      weights_.reorder_from(weights);
+      if (weights_.get_data_type() != data_type::f16) {
+        weights_.init(weights.get_desc().to_type(data_type::f16));
+        weights_.reorder_from(weights);
+      }
     }
 
     // workaround: diff_src and weights from caffe2 may have different dims.

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -348,17 +348,18 @@ private:
     }
 
     IDEEP_ENFORCE(utils::one_of(weights.get_data_type(),
-                                data_type::f32, data_type::bf16),
+                                data_type::f32, data_type::bf16, data_type::f16),
             "Incorrect data type in weights");
-
     // align weights data type with src
-    dst_data_type = src.get_data_type() == data_type::bf16 ? data_type::bf16
-                                                           : data_type::f32;
+    dst_data_type = src.get_data_type() == data_type::bf16
+        ? data_type::bf16
+        : ((src.get_data_type() == data_type::f16) ? data_type::f16
+                                                   : data_type::f32);
     src_desc = {src.get_dims(), dst_data_type, format_tag::any};
     weights_desc = {weights.get_dims(), dst_data_type, format_tag::any};
     if (with_bias) {
       IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
-                                  data_type::f32, data_type::bf16),
+                                  data_type::f32, data_type::bf16, data_type::f16),
                     "Incorrect data type in bias");
       bias_desc = bias.get_desc().to_format_any();
     }
@@ -561,6 +562,9 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
     auto weights_ = weights;
     if (diff_dst.get_data_type() == data_type::bf16) {
       weights_.init(weights.get_desc().to_type(data_type::bf16));
+      weights_.reorder_from(weights);
+    } else if (diff_dst.get_data_type() == data_type::f16) {
+      weights_.init(weights.get_desc().to_type(data_type::f16));
       weights_.reorder_from(weights);
     }
 


### PR DESCRIPTION
Add fp16 support for non-quantization version of convolution and inner_product to enable fp16 support on IPEX.
At present, only Bert and RN50 need to be tested, and conv & linear should run into fp16 kernels of oneDNN.