### PR TITLE
[matmul] define the dest descriptor format based on tensor dimensions

### DIFF
--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -826,7 +826,10 @@ struct matmul_forward : public dnnl::matmul,
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     dst_data_type = dst_type == data_type::undef ? dst_data_type : dst_type;
-    tensor::desc dst_desc = tensor::desc(dst_dims, dst_data_type, tag::any);
+    /* rely on tensor descriptor class to se the format appropriately
+     * based on the tensor dimensions.
+     */
+    tensor::desc dst_desc = tensor::desc(dst_dims, dst_data_type);
     if (!dst.is_empty()) {
       dst_desc = dst.get_desc().to_type(dst_data_type);
     }


### PR DESCRIPTION
Arm Compute Library expects destination format tag to be set according to the dimensions.
Updated the initialization logic to rely on tensor descriptor class to set the format appropriately
based on the tensor dimensions.

since i made the change platform agnostic, I've tested x86 as well.
I have executed the PyTorch UT on AWS c6i (x86) instances and here are the results. In summary there is no regression with this PR, in fact 3 tests are additionally passing on test_ops.py and 1 additional test passing from test_quantization compared to the PyTorch master. I will keep you posted on the IPEX UT.

**PyTorch master:**
test_ops.py:

> Ran 25514 tests in 1062.573s
>
> FAILED (failures=20, errors=69, skipped=8001, expected failures=276)

test_mkldnn.py:

> Ran 67 tests in 19.717s
>
> OK

test_mkldnn_fusion.py:

> Ran 3 tests in 77.529s
> 
> OK

test_mkldnn_verbose.py:

> Ran 2 tests in 1.657s
> 
> OK

test_quantization.py:

> Ran 930 tests in 382.495s
>
> FAILED (failures=1, skipped=65)

**PyTorch master + with this pr:**
test_ops.py:

> Ran 25514 tests in 1063.838s
> 
> FAILED (failures=17, errors=69, skipped=8001, expected failures=276)

test_mkldnn.py:

> Ran 67 tests in 19.446s
> 
> OK

test_mkldnn_fusion.py:

> Ran 3 tests in 77.601s
> 
> OK


test_mkldnn_verbose.py:

> Ran 2 tests in 1.659s
> 
> OK

test_quantization.py:

> Ran 930 tests in 383.025s
> 
> OK (skipped=65)


I've tested the IPEX unit tests as well. All the tests shown ~3-10% latency improvement (took fewer secs to finish) with this patch. 

> intel-extension-for-pytorch/tests/cpu$ test_*