### PR TITLE
Migrate to oneDNN 3.0 API

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -167,7 +167,7 @@ struct attr_t : public dnnl::primitive_attr {
     return fuse_eltwise(gelu_type, alpha, beta);
   }
 
-  static attr_t fuse_gelu(
+  static attr_t fuse_gelu_v2(
       float alpha = 0.f,
       float beta = 0.f,
       algorithm gelu_type = algorithm::eltwise_gelu_erf) {
@@ -182,7 +182,7 @@ struct attr_t : public dnnl::primitive_attr {
     return fuse_eltwise(algorithm::eltwise_elu, alpha, beta);
   }
 
-  static attr_t fuse_elu(
+  static attr_t fuse_elu_v2(
       float alpha = 0.f,
       float beta = 1.0) {
     return fuse_eltwise(algorithm::eltwise_elu, alpha, beta);
@@ -278,7 +278,7 @@ struct attr_t : public dnnl::primitive_attr {
     return fuse_eltwise(algorithm::eltwise_pow, alpha, beta);
   }
 
-  static attr_t fuse_pow(
+  static attr_t fuse_pow_v2(
       float alpha = 1.0,
       float beta = 0.f) {
     return fuse_eltwise(algorithm::eltwise_pow, alpha, beta);

--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -212,8 +212,8 @@ struct attr_t : public dnnl::primitive_attr {
 
   static attr_t fuse_hardswish(
       float scale = 1.0,
-      float alpha = 1.0,
-      float beta = 0.f) {
+      float alpha = 1.0f / 6.0f,
+      float beta = 0.5f) {
     attr_t attr;
     post_ops po;
     po.append_eltwise(scale, algorithm::eltwise_hardswish, alpha, beta);

--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -389,9 +389,8 @@ struct attr_t : public dnnl::primitive_attr {
         dnnl_primitive_attr_clone(&result, rhs.get()),
         "could not clone primitive attributes");
     this->reset(result);
-    int c_mask, z_mask;
+    int c_mask;
     scale_t scales;
-    zero_point_t zero_points;
     std::tie(scales, c_mask) = rhs.get_output_scales();
     if (scales_) {
       *scales_ = scales;

--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -7,7 +7,13 @@
 namespace ideep {
 
 using post_ops = dnnl::post_ops;
-using zero_point_map = std::unordered_map<int, zero_point_t>;
+using scale_mask_pair = std::pair<scale_t, int>;
+using zp_mask_pair = std::pair<zero_point_t, int>;
+// Map DNNL arg to pair of scales and mask
+using scale_map = std::unordered_map<int, scale_mask_pair>;
+// Map DNNL arg to pair of zero points and mask
+using zero_point_map = std::unordered_map<int, zp_mask_pair>;
+static const scale_map empty_scale_map;
 static const zero_point_map empty_zp_map;
 
 /// Attribute class for extra information into computations
@@ -20,10 +26,22 @@ struct attr_t : public dnnl::primitive_attr {
 
   attr_t(const dnnl::primitive_attr& other) : dnnl::primitive_attr(other) {}
 
+  /// @param arg Parameter argument index
+  attr_t(int arg, int mask, const scale_t& scales) {
+    set_scales_mask(arg, mask);
+    if (!scales_) {
+      scales_.reset(new scale_map());
+    }
+    (*scales_)[arg] = std::make_pair(scales, mask);
+  }
+
+  // Defualt arg = DNNL_ARG_DST
   attr_t(int mask, const scale_t& scales) {
-    // set_output_scales(mask, scales);
-    set_output_scales_mask(mask);
-    scales_.reset(new scale_t(scales));
+    set_scales_mask(DNNL_ARG_DST, mask);
+    if (!scales_) {
+      scales_.reset(new scale_map());
+    }
+    (*scales_)[DNNL_ARG_DST] = std::make_pair(scales, mask);
   }
 
   attr_t(dnnl_fpmath_mode_t fpmath_mode,
@@ -39,54 +57,62 @@ struct attr_t : public dnnl::primitive_attr {
     return *this;
   }
 
-  void set_output_scales(int mask, const scale_t& scales) {
-    set_output_scales_mask(mask);
+  /// @param arg Parameter argument index, e.g. DNNL_ARG_SRC
+  void set_scales(int arg, int mask, const scale_t& scales) {
+    set_scales_mask(arg, mask);
     if (!scales_) {
-      scales_.reset(new scale_t(scales));
-    } else {
-      *scales_ = scales;
+      scales_.reset(new scale_map());
     }
+    (*scales_)[arg] = std::make_pair(scales, mask);
   }
 
-  std::pair<scale_t, int> get_output_scales() const {
-    if (!scales_) {
-      return std::make_pair(scale_t(), 0);
-    }
-    int c_mask = utils::op_scale_mask(scales_->size());
-    return std::make_pair(*scales_, c_mask);
+  /// @param arg Parameter argument index, e.g. DNNL_ARG_SRC
+  scale_mask_pair& get_scales(int arg) const {
+    IDEEP_ENFORCE(has_scales_for(arg),
+                  "Scales for arg not found!");
+    return (*scales_)[arg];
   }
 
-  bool has_output_scales() const {
+  const scale_map& get_all_scales() const {
+    return scales_ ? *scales_ : empty_scale_map;
+  }
+
+  bool has_scales() const {
     return (scales_ && !(*scales_).empty());
   }
 
-  // @param arg DNNL_ARGS
+  /// @param arg Parameter argument index, e.g. DNNL_ARG_SRC
+  bool has_scales_for(int arg) const {
+    return has_scales() && scales_->count(arg);
+  }
+
+  /// @param arg Parameter argument index, e.g. DNNL_ARG_SRC
   void set_zero_points(int arg, int mask, const zero_point_t& zero_points) {
     set_zero_points_mask(arg, mask);
     if (!zero_points_) {
       zero_points_.reset(new zero_point_map());
     }
-    (*zero_points_)[arg] = zero_points;
+    (*zero_points_)[arg] = std::make_pair(zero_points, mask);
   }
 
-  std::pair<zero_point_t, int> get_zero_points(int arg) const {
-    if (!zero_points_ || !zero_points_->count(arg)) {
-      return std::make_pair(zero_point_t(), 0);
-    }
-    auto& zp = (*zero_points_)[arg];
-    int mask = utils::tensor_zp_mask(zp.size());
-    return std::make_pair(zp, mask);
+  /// @param arg Parameter argument index, e.g. DNNL_ARG_SRC
+  zp_mask_pair& get_zero_points(int arg) const {
+    IDEEP_ENFORCE(has_zero_points_for(arg),
+                  "Zero point for arg not found!");
+    return (*zero_points_)[arg];
   }
 
   const zero_point_map& get_all_zero_points() const {
-    if (!zero_points_) {
-      return empty_zp_map;
-    }
-    return *zero_points_;
+    return zero_points_ ? *zero_points_ : empty_zp_map;
   }
 
   bool has_zero_points() const {
     return (zero_points_ && !(*zero_points_).empty());
+  }
+
+  /// @param arg Parameter argument index, e.g. DNNL_ARG_SRC
+  bool has_zero_points_for(int arg) const {
+    return has_zero_points() && zero_points_->count(arg);
   }
 
   // Helper factory
@@ -205,7 +231,7 @@ struct attr_t : public dnnl::primitive_attr {
   static attr_t fuse_hardswish(
       float alpha = 1.0f / 6.0f,
       float beta = 0.5f) {
-    return fuse_eltwise(algorithm::eltwise_clip, alpha, beta);
+    return fuse_eltwise(algorithm::eltwise_hardswish, alpha, beta);
   }
 
   static attr_t fuse_abs(
@@ -334,6 +360,7 @@ struct attr_t : public dnnl::primitive_attr {
     return true;
   }
 
+  // deep data copy
   attr_t& operator=(const attr_t& rhs) {
     if (this == &rhs) {
       return *this;
@@ -343,18 +370,19 @@ struct attr_t : public dnnl::primitive_attr {
         dnnl_primitive_attr_clone(&result, rhs.get()),
         "could not clone primitive attributes");
     this->reset(result);
-    int c_mask;
-    scale_t scales;
-    std::tie(scales, c_mask) = rhs.get_output_scales();
-    if (scales_) {
-      *scales_ = scales;
-    } else {
-      scales_.reset(new scale_t(scales));
+    if (rhs.has_scales()) {
+      if (scales_) {
+        *scales_ = rhs.get_all_scales();
+      } else {
+        scales_.reset(new scale_map(rhs.get_all_scales()));
+      }
     }
-    if (zero_points_) {
-      *zero_points_ = rhs.get_all_zero_points();
-    } else {
-      zero_points_.reset(new zero_point_map(rhs.get_all_zero_points()));
+    if (rhs.has_zero_points()) {
+      if (zero_points_) {
+        *zero_points_ = rhs.get_all_zero_points();
+      } else {
+        zero_points_.reset(new zero_point_map(rhs.get_all_zero_points()));
+      }
     }
     return *this;
   }
@@ -416,17 +444,20 @@ struct attr_t : public dnnl::primitive_attr {
     }
 
     // encode output scales
-    if (has_output_scales()) {
-      auto scales = get_output_scales();
-      utils::to_bytes(bytes, scales.first);
-      utils::to_bytes(bytes, scales.second);
+    if (has_scales()) {
+      for (auto& scales : get_all_scales()) {
+        utils::to_bytes(bytes, scales.first); // dnnl arg index
+        utils::to_bytes(bytes, scales.second.first); // scale vector
+        utils::to_bytes(bytes, scales.second.second); // mask
+      }
     }
 
     // encode zero points
     if (has_zero_points()) {
       for (auto& zp : get_all_zero_points()) {
-        utils::to_bytes(bytes, zp.first);
-        utils::to_bytes(bytes, zp.second);
+        utils::to_bytes(bytes, zp.first); // dnnl arg index
+        utils::to_bytes(bytes, zp.second.first); // zero point vector
+        utils::to_bytes(bytes, zp.second.second); // mask
       }
     }
 
@@ -436,9 +467,8 @@ struct attr_t : public dnnl::primitive_attr {
   }
 
 private:
-  std::shared_ptr<scale_t> scales_;
-  // Map key: DNNL ARG (e.g. DNNL_ARG_SRC)
-  std::shared_ptr<std::unordered_map<int, zero_point_t>> zero_points_;
+  std::shared_ptr<scale_map> scales_;
+  std::shared_ptr<zero_point_map> zero_points_;
 };
 
 } // namespace ideep

--- a/include/ideep/operators/batchnorm.hpp
+++ b/include/ideep/operators/batchnorm.hpp
@@ -68,13 +68,6 @@ struct batch_normalization_forward_inference
         aengine, prop_kind::forward_inference,
         src_desc, src_desc, epsilon, pd_flags, attr);
 
-    // tensor scale_shift{pd.weights_desc()};
-    // auto* scale_shift_buf = static_cast<char*>(scale_shift.get_data_handle());
-    // std::memcpy(scale_shift_buf, scale.get_data_handle(), scale.get_size());
-    // std::memcpy(
-    //     scale_shift_buf + scale.get_size(),
-    //     shift.get_data_handle(),
-    //     shift.get_size());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     dst.reinit_if_possible(pd.dst_desc());
     tensor scratchpad(pd.scratchpad_desc());
@@ -85,7 +78,6 @@ struct batch_normalization_forward_inference
       super(pd).execute(
           stream::default_stream(),
           {{DNNL_ARG_SRC, expected_src},
-           // {DNNL_ARG_WEIGHTS/* DNNL_ARG_SCALE_SHIFT */, scale_shift},
            {DNNL_ARG_SCALE, scale},
            {DNNL_ARG_SHIFT, shift},
            {DNNL_ARG_VARIANCE, expected_var},
@@ -96,7 +88,6 @@ struct batch_normalization_forward_inference
       super(pd).execute(
           stream::default_stream(),
           {{DNNL_ARG_SRC, expected_src},
-           // {DNNL_ARG_WEIGHTS/* DNNL_ARG_SCALE_SHIFT */, scale_shift},
            {DNNL_ARG_SCALE, scale},
            {DNNL_ARG_SHIFT, shift},
            {DNNL_ARG_DST, dst},
@@ -139,13 +130,6 @@ struct batch_normalization_forward_training
         prop_kind::forward_training, src_desc, src_desc, epsilon, pd_flags,
         op_attr);
 
-    // tensor scale_shift(pd.weights_desc());
-    // auto* scale_shift_buf = static_cast<char*>(scale_shift.get_data_handle());
-    // std::memcpy(scale_shift_buf, scale.get_data_handle(), scale.get_size());
-    // std::memcpy(
-    //     scale_shift_buf + scale.get_size(),
-    //     shift.get_data_handle(),
-    //     shift.get_size());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     mean.reinit_if_possible(pd.mean_desc());
     variance.reinit_if_possible(pd.variance_desc());
@@ -154,7 +138,6 @@ struct batch_normalization_forward_training
 
     exec_args args{
         {DNNL_ARG_SRC, expected_src},
-        // {DNNL_ARG_WEIGHTS/* DNNL_ARG_SCALE_SHIFT */, scale_shift},
         {DNNL_ARG_SCALE, scale},
         {DNNL_ARG_SHIFT, shift},
         {DNNL_ARG_MEAN, mean},

--- a/include/ideep/operators/batchnorm.hpp
+++ b/include/ideep/operators/batchnorm.hpp
@@ -243,12 +243,11 @@ struct batch_normalization_backward
     exec_args args{
         {DNNL_ARG_SRC, expected_src},
         {DNNL_ARG_DIFF_DST, expected_diff_dst},
-        // {DNNL_ARG_WEIGHTS/* DNNL_ARG_SCALE_SHIFT */, scale}, // only need scale
         {DNNL_ARG_SCALE, scale},
         {DNNL_ARG_MEAN, expected_mean},
         {DNNL_ARG_VARIANCE, expected_variance},
         {DNNL_ARG_DIFF_SRC, diff_src},
-        {DNNL_ARG_DIFF_SCALE/* DNNL_ARG_DIFF_SCALE_SHIFT */, diff_scale_shift},
+        {DNNL_ARG_DIFF_SCALE, diff_scale_shift},
         {DNNL_ARG_SCRATCHPAD, scratchpad}};
     if (with_workspace) {
       args.insert({DNNL_ARG_WORKSPACE, dst.get_workspace()});

--- a/include/ideep/operators/batchnorm.hpp
+++ b/include/ideep/operators/batchnorm.hpp
@@ -205,12 +205,10 @@ struct batch_normalization_backward
       float epsilon,
       const tensor& dst = tensor(),
       const batch_normalization_flag flags =
-          batch_normalization_flag::use_scale |
-          batch_normalization_flag::use_shift,
+          batch_normalization_flag::use_scale,
       const engine& aengine = engine::cpu_engine()) {
     // TODO: support no-affine model
-    auto pd_flags = flags | batch_normalization_flag::use_scale |
-                    batch_normalization_flag::use_shift;
+    auto pd_flags = flags | batch_normalization_flag::use_scale;
     bool with_workspace =
         (bool)(flags & batch_normalization_flag::fuse_norm_relu);
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
@@ -250,7 +248,7 @@ struct batch_normalization_backward
         {DNNL_ARG_MEAN, expected_mean},
         {DNNL_ARG_VARIANCE, expected_variance},
         {DNNL_ARG_DIFF_SRC, diff_src},
-        {DNNL_ARG_DIFF_WEIGHTS/* DNNL_ARG_DIFF_SCALE_SHIFT */, diff_scale_shift},
+        {DNNL_ARG_DIFF_SCALE/* DNNL_ARG_DIFF_SCALE_SHIFT */, diff_scale_shift},
         {DNNL_ARG_SCRATCHPAD, scratchpad}};
     if (with_workspace) {
       args.insert({DNNL_ARG_WORKSPACE, dst.get_workspace()});

--- a/include/ideep/operators/binary.hpp
+++ b/include/ideep/operators/binary.hpp
@@ -20,7 +20,7 @@ struct binary : public dnnl::binary {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aalgorithm, src0_desc, src1_desc, dst_desc}, op_attr, aengine);
+        aengine, aalgorithm, src0_desc, src1_desc, dst_desc, op_attr);
 
     tensor scratchpad(pd.scratchpad_desc());
 

--- a/include/ideep/operators/channel_shuffle.hpp
+++ b/include/ideep/operators/channel_shuffle.hpp
@@ -22,7 +22,7 @@ struct channel_shuffle_forward : public dnnl::shuffle_forward {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aprop_kind, src.get_desc(), axis, group_size}, aengine, op_attr);
+        aengine, aprop_kind, src.get_desc(), src.get_desc(), axis, group_size, op_attr);
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     dst.reinit_if_possible(pd.dst_desc());
@@ -50,13 +50,13 @@ struct channel_shuffle_backward : public dnnl::shuffle_backward {
     auto data_desc = diff_dst.get_desc();
 
     auto forward_hints = dnnl::shuffle_forward::primitive_desc(
-        {prop_kind::forward, data_desc, group_size, axis}, aengine);
+        aengine, prop_kind::forward, data_desc, data_desc, group_size, axis);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {data_desc, axis, group_size}, aengine, forward_hints, op_attr);
+        aengine, data_desc, data_desc, axis, group_size, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());

--- a/include/ideep/operators/concat.hpp
+++ b/include/ideep/operators/concat.hpp
@@ -20,7 +20,7 @@ struct concat : public dnnl::concat {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     // create a pd to query the optimimal format for src and dst
-    auto pd = primitive_desc(axis, input_descs, aengine, op_attr);
+    auto pd = primitive_desc(aengine, axis, input_descs, op_attr);
     auto expected_desc = tensor::desc(pd.dst_desc());
 
     output.reinit_if_possible(expected_desc);
@@ -46,7 +46,7 @@ struct concat : public dnnl::concat {
         return static_cast<memory::desc>(t.get_desc());
       });
       // recreate the pd on new inputs with same formats
-      pd = primitive_desc(axis, input_descs, aengine, op_attr);
+      pd = primitive_desc(aengine, axis, input_descs, op_attr);
     }
 
     tensor scratchpad(pd.scratchpad_desc());

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1748,9 +1748,10 @@ private:
       if (!param.all_scales) {
         param.all_scales.reset(new std::unordered_map<int, tensor>);
       }
+      // get_all_scales() returns unordered_map<int, pair of scale and mask>
       for (auto& arg_scale_pair : param.op_attr.get_all_scales()) {
         int dnnl_arg = arg_scale_pair.first;
-        const scale_t& scale = arg_scale_pair.second.first;
+        const scale_t& scale = std::get<0>(std::get<1>(arg_scale_pair));
         tensor scales_m(scale);
         param.all_scales->insert({dnnl_arg, scales_m});
       }
@@ -1759,9 +1760,10 @@ private:
       if (!param.all_zero_points) {
         param.all_zero_points.reset(new std::unordered_map<int, tensor>);
       }
+      // get_all_zero_points() returns unordered_map<int, pair of zp and mask>
       for (auto& arg_zp_pair : param.op_attr.get_all_zero_points()) {
         int dnnl_arg = arg_zp_pair.first;
-        const zero_point_t& zp = arg_zp_pair.second.first;
+        const zero_point_t& zp = std::get<0>(std::get<1>(arg_zp_pair));
         tensor zp_m(zp);
         param.all_zero_points->insert({dnnl_arg, zp_m});
       }
@@ -1797,14 +1799,14 @@ private:
     if (param.all_scales && !param.all_scales->empty()) {
       for (auto& arg_scale_pair : *param.all_scales) {
         int dnnl_arg = arg_scale_pair.first;
-        tensor& scales_m = arg_scale_pair.second;
+        tensor& scales_m = std::get<1>(arg_scale_pair);
         args.insert({DNNL_ARG_ATTR_SCALES | dnnl_arg, scales_m});
       }
     }
     if (param.all_zero_points && !param.all_zero_points->empty()) {
       for (auto& arg_zp_pair : *param.all_zero_points) {
         int dnnl_arg = arg_zp_pair.first;
-        tensor& zp_m = arg_zp_pair.second;
+        tensor& zp_m = std::get<1>(arg_zp_pair);
         args.insert({DNNL_ARG_ATTR_ZERO_POINTS | dnnl_arg, zp_m});
       }
     }

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1449,31 +1449,32 @@ struct convolution_forward
     return fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(
-            {aprop_kind,
-             aalgorithm,
-             src_desc_query,
-             weights_desc_query,
-             bias_desc_query,
-             dst_desc_query,
-             strides,
-             dilates,
-             padding_l,
-             padding_r},
-            attr,
-            aengine);
+            aengine,
+            aprop_kind,
+            aalgorithm,
+            src_desc_query,
+            weights_desc_query,
+            bias_desc_query,
+            dst_desc_query,
+            strides,
+            dilates,
+            padding_l,
+            padding_r,
+            attr
+            );
       } else {
         return primitive_desc(
-            {aprop_kind,
-             aalgorithm,
-             src_desc_query,
-             weights_desc_query,
-             dst_desc_query,
-             strides,
-             dilates,
-             padding_l,
-             padding_r},
-            attr,
-            aengine);
+            aengine,
+            aprop_kind,
+            aalgorithm,
+            src_desc_query,
+            weights_desc_query,
+            dst_desc_query,
+            strides,
+            dilates,
+            padding_l,
+            padding_r,
+            attr);
       }
     });
   }
@@ -1872,8 +1873,8 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
-         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
+        aengine, aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
+        dilates_, padding_l, padding_r, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
@@ -1925,8 +1926,8 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
             dilates_, padding_l, padding_r, is_channels_last, op_attr);
 
     auto pd = primitive_desc(
-        {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
-         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
+        aengine, aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
+        dilates_, padding_l, padding_r, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
@@ -2117,12 +2118,12 @@ struct convolution_backward_weights
             prop_kind::forward, aengine);
 
     auto pd = with_diff_bias
-        ? primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_bias_desc, diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints)
-        : primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints);
+        ? primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
+                         diff_bias_desc, diff_dst_desc, strides, dilates_,
+                         padding_l, padding_r, forward_hints, op_attr)
+        : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
+                         diff_dst_desc, strides, dilates_,
+                         padding_l, padding_r, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1380,6 +1380,7 @@ struct convolution_forward
         src_desc_query,
         weights_desc_query,
         with_bias,
+        bias_desc_query,
         strides,
         dilates,
         padding_l,

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -675,9 +675,6 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
                   strides, dil_compatible, padding_l, padding_r, op_attr, aalgorithm,
                   aprop_kind, aengine);
 
-    tensor src_zero_point_m;
-    conv_deconv_utils::obtain_runtime_zero_point(src, src_zero_point, DNNL_ARG_SRC,
-                                                 op_attr, aengine, src_zero_point_m);
     param.primitive = std::move(super(param.pd));
     param.op_attr = std::move(op_attr);
     param.bias_attr = std::move(bias_attr);

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -3,18 +3,6 @@
 
 namespace ideep {
 
-struct deconv_forward_quant_params {
-  deconv_forward_quant_params() {}
-
-  deconv_forward_quant_params(tensor&& src_zero_point)
-      : src_zero_point(std::move(src_zero_point)) {}
-
-  // Due to oneDNN's mechanism of deconv, zero point is set to
-  // runtime value when weight is prepacked without input info in framework.
-  // So, the true zero point is set at primitive execution time
-  tensor src_zero_point;
-};
-
 struct deconv_forward_params {
   deconv_forward_params() {}
 

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -527,15 +527,13 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
     auto dst_desc_query = dst_desc.to_format(format_tag);
 
     if (with_bias) {
-      return primitive_desc({aprop_kind, aalgorithm, src_desc_query,
-                             weights_desc_query, bias_desc_query, dst_desc_query,
-                             strides, dilates, padding_l, padding_r},
-                            attr, aengine);
+      return primitive_desc(aengine, aprop_kind, aalgorithm, src_desc_query,
+                            weights_desc_query, bias_desc_query, dst_desc_query,
+                            strides, dilates, padding_l, padding_r, attr);
     } else {
-      return primitive_desc({aprop_kind, aalgorithm, src_desc_query,
-                             weights_desc_query, dst_desc_query,
-                             strides, dilates, padding_l, padding_r},
-                            attr, aengine);
+      return primitive_desc(aengine, aprop_kind, aalgorithm, src_desc_query,
+                            weights_desc_query, dst_desc_query,
+                            strides, dilates, padding_l, padding_r, attr);
     }
   }
 
@@ -766,8 +764,8 @@ struct convolution_transpose_backward_data
             dilates_, padding_l, padding_r, op_attr);
 
     auto pd = primitive_desc(
-        {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
-         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
+        aengine, aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
+        dilates_, padding_l, padding_r, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
@@ -874,12 +872,12 @@ private:
             prop_kind::forward, aengine);
 
     auto pd = with_diff_bias
-        ? primitive_desc({aalgorithm, src_desc, diff_weights_desc,
-                          diff_bias_desc, diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints)
-        : primitive_desc({aalgorithm, src_desc, diff_weights_desc,
+        ? primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
+                         diff_bias_desc, diff_dst_desc, strides, dilates_,
+                         padding_l, padding_r, forward_hints, op_attr)
+        : primitive_desc(aengine, aalgorithm, src_desc, diff_weights_desc,
                           diff_dst_desc, strides, dilates_,
-                          padding_l, padding_r}, op_attr, aengine, forward_hints);
+                          padding_l, padding_r, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());

--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -26,7 +26,7 @@ struct eltwise_forward : public dnnl::eltwise_forward {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aprop_kind, aalgorithm, src_desc, alpha, beta}, op_attr, aengine);
+        aengine, aprop_kind, aalgorithm, src_desc, src_desc, alpha, beta, op_attr);
 
     dst.reinit_if_possible(pd.dst_desc());
     if (src_in.has_scale()) {
@@ -63,16 +63,14 @@ struct eltwise_backward : public dnnl::eltwise_backward {
     auto src_desc = src.get_desc();
 
     auto forward_hints = eltwise_forward::primitive_desc(
-        {prop_kind::forward, aalgorithm, src_desc, alpha, beta}, aengine);
+        aengine, prop_kind::forward, aalgorithm, src_desc, src_desc, alpha, beta);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aalgorithm, forward_hints.dst_desc(), src_desc, alpha, beta},
-        op_attr,
-        aengine,
-        forward_hints);
+        aengine, aalgorithm, forward_hints.src_desc(), forward_hints.dst_desc(),
+        src_desc, alpha, beta, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -558,17 +558,6 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
                       const attr_t& attr = attr_t(),
                       const engine& aengine = engine::cpu_engine()) {
     auto weights_ = weights;
-    // if (diff_dst.get_data_type() == data_type::bf16) {
-    //   if (weights_.get_data_type() != data_type::bf16) {
-    //     weights_.init(weights.get_desc().to_type(data_type::bf16));
-    //     weights_.reorder_from(weights);
-    //   }
-    // } else if (diff_dst.get_data_type() == data_type::f16) {
-    //   if (weights_.get_data_type() != data_type::f16) {
-    //     weights_.init(weights.get_desc().to_type(data_type::f16));
-    //     weights_.reorder_from(weights);
-    //   }
-    // }
 
     // workaround: diff_src and weights from caffe2 may have different dims.
     // It would be better for caffe2 to do this reshape anyway.
@@ -579,7 +568,6 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
     }
 
     auto diff_dst_desc = diff_dst.get_desc().to_format_any();
-    // auto weights_desc = weights_.get_desc();
     auto weights_desc = tensor::desc(weights_.get_dims(), diff_dst.get_data_type(), tag::any);
     auto diff_src_desc =
         tensor::desc(diff_src_dims, diff_dst.get_data_type(), tag::any);

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -236,7 +236,7 @@ struct inner_product_forward
     tensor::desc dst_desc(y_dims, y_dtype, tag::any);
     tensor::desc weights_desc(weights_dims, dtype, tag::any);
     auto pd =
-        primitive_desc({aprop_kind, src_desc, weights_desc, dst_desc}, aengine);
+        primitive_desc(aengine, aprop_kind, src_desc, weights_desc, dst_desc);
     return pd.weights_desc();
   }
 
@@ -261,12 +261,10 @@ struct inner_product_forward
     return fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(
-            {aprop_kind, src_desc, weights_desc, bias_desc, dst_desc},
-            attr,
-            aengine);
+            aengine, aprop_kind, src_desc, weights_desc, bias_desc, dst_desc, attr);
       } else {
         return primitive_desc(
-            {aprop_kind, src_desc, weights_desc, dst_desc}, attr, aengine);
+            aengine, aprop_kind, src_desc, weights_desc, dst_desc, attr);
       }
     });
   };
@@ -592,7 +590,7 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
         diff_src_desc, weights_desc, diff_dst_desc, tensor::desc(), false, op_attr);
 
     auto pd = primitive_desc(
-        {diff_src_desc, weights_desc, diff_dst_desc}, op_attr, aengine, forward_hints);
+        aengine, diff_src_desc, weights_desc, diff_dst_desc, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
@@ -686,10 +684,10 @@ private:
         src_desc, weights_desc, diff_dst_desc, diff_bias_desc, with_diff_bias, op_attr);
 
     auto pd = with_diff_bias
-        ? primitive_desc({src_desc, diff_weights_desc, diff_bias_desc,
-                          diff_dst_desc}, op_attr, aengine, forward_hints)
-        : primitive_desc({src_desc, diff_weights_desc, diff_dst_desc},
-                          op_attr, aengine, forward_hints);
+        ? primitive_desc(aengine, src_desc, diff_weights_desc, diff_bias_desc,
+                         diff_dst_desc, forward_hints, op_attr)
+        : primitive_desc(aengine, src_desc, diff_weights_desc, diff_dst_desc,
+                         forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -558,17 +558,17 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
                       const attr_t& attr = attr_t(),
                       const engine& aengine = engine::cpu_engine()) {
     auto weights_ = weights;
-    if (diff_dst.get_data_type() == data_type::bf16) {
-      if (weights_.get_data_type() != data_type::bf16) {
-        weights_.init(weights.get_desc().to_type(data_type::bf16));
-        weights_.reorder_from(weights);
-      }
-    } else if (diff_dst.get_data_type() == data_type::f16) {
-      if (weights_.get_data_type() != data_type::f16) {
-        weights_.init(weights.get_desc().to_type(data_type::f16));
-        weights_.reorder_from(weights);
-      }
-    }
+    // if (diff_dst.get_data_type() == data_type::bf16) {
+    //   if (weights_.get_data_type() != data_type::bf16) {
+    //     weights_.init(weights.get_desc().to_type(data_type::bf16));
+    //     weights_.reorder_from(weights);
+    //   }
+    // } else if (diff_dst.get_data_type() == data_type::f16) {
+    //   if (weights_.get_data_type() != data_type::f16) {
+    //     weights_.init(weights.get_desc().to_type(data_type::f16));
+    //     weights_.reorder_from(weights);
+    //   }
+    // }
 
     // workaround: diff_src and weights from caffe2 may have different dims.
     // It would be better for caffe2 to do this reshape anyway.
@@ -579,7 +579,8 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
     }
 
     auto diff_dst_desc = diff_dst.get_desc().to_format_any();
-    auto weights_desc = weights_.get_desc();
+    // auto weights_desc = weights_.get_desc();
+    auto weights_desc = tensor::desc(weights_.get_dims(), diff_dst.get_data_type(), tag::any);
     auto diff_src_desc =
         tensor::desc(diff_src_dims, diff_dst.get_data_type(), tag::any);
 

--- a/include/ideep/operators/layernorm.hpp
+++ b/include/ideep/operators/layernorm.hpp
@@ -24,13 +24,13 @@ struct layer_normalization_forward : public dnnl::layer_normalization_forward {
         aengine, prop_kind::forward_training, src_desc, src_desc,
         epsilon, flags, op_attr);
 
-    tensor scale_shift{pd.weights_desc()};
-    auto* scale_shift_buf = static_cast<char*>(scale_shift.get_data_handle());
-    std::memcpy(scale_shift_buf, scale.get_data_handle(), scale.get_size());
-    std::memcpy(
-        scale_shift_buf + scale.get_size(),
-        shift.get_data_handle(),
-        shift.get_size());
+    // tensor scale_shift(pd.weights_desc());
+    // auto* scale_shift_buf = static_cast<char*>(scale_shift.get_data_handle());
+    // std::memcpy(scale_shift_buf, scale.get_data_handle(), scale.get_size());
+    // std::memcpy(
+    //     scale_shift_buf + scale.get_size(),
+    //     shift.get_data_handle(),
+    //     shift.get_size());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     mean.reinit_if_possible(pd.mean_desc());
     variance.reinit_if_possible(pd.variance_desc());
@@ -40,7 +40,9 @@ struct layer_normalization_forward : public dnnl::layer_normalization_forward {
     super(pd).execute(
         stream::default_stream(),
         {{DNNL_ARG_SRC, expected_src},
-         {DNNL_ARG_WEIGHTS/* DNNL_ARG_SCALE_SHIFT */, scale_shift},
+         // {DNNL_ARG_WEIGHTS/* DNNL_ARG_SCALE_SHIFT */, scale_shift},
+         {DNNL_ARG_SCALE, scale},
+         {DNNL_ARG_SHIFT, shift},
          {DNNL_ARG_MEAN, mean},
          {DNNL_ARG_VARIANCE, variance},
          {DNNL_ARG_DST, dst},

--- a/include/ideep/operators/layernorm.hpp
+++ b/include/ideep/operators/layernorm.hpp
@@ -24,13 +24,6 @@ struct layer_normalization_forward : public dnnl::layer_normalization_forward {
         aengine, prop_kind::forward_training, src_desc, src_desc,
         epsilon, flags, op_attr);
 
-    // tensor scale_shift(pd.weights_desc());
-    // auto* scale_shift_buf = static_cast<char*>(scale_shift.get_data_handle());
-    // std::memcpy(scale_shift_buf, scale.get_data_handle(), scale.get_size());
-    // std::memcpy(
-    //     scale_shift_buf + scale.get_size(),
-    //     shift.get_data_handle(),
-    //     shift.get_size());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     mean.reinit_if_possible(pd.mean_desc());
     variance.reinit_if_possible(pd.variance_desc());
@@ -40,7 +33,6 @@ struct layer_normalization_forward : public dnnl::layer_normalization_forward {
     super(pd).execute(
         stream::default_stream(),
         {{DNNL_ARG_SRC, expected_src},
-         // {DNNL_ARG_WEIGHTS/* DNNL_ARG_SCALE_SHIFT */, scale_shift},
          {DNNL_ARG_SCALE, scale},
          {DNNL_ARG_SHIFT, shift},
          {DNNL_ARG_MEAN, mean},

--- a/include/ideep/operators/lrn.hpp
+++ b/include/ideep/operators/lrn.hpp
@@ -24,9 +24,8 @@ struct lrn_forward : public dnnl::lrn_forward {
 
     // auto src_desc = src.get_desc();
     auto pd = primitive_desc(
-        {aprop_kind, aalgorithm, src_desc, local_size, alpha, beta, k},
-        op_attr,
-        aengine);
+        aengine, aprop_kind, aalgorithm, src_desc, src_desc,
+        local_size, alpha, beta, k, op_attr);
 
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
     dst.reinit_if_possible(pd.dst_desc());
@@ -65,23 +64,15 @@ struct lrn_backward : public dnnl::lrn_backward {
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
     // auto src_desc = src.get_desc();
     auto forward_hints = lrn_forward::primitive_desc(
-        {prop_kind::forward_training,
-         aalgorithm,
-         src_desc,
-         local_size,
-         alpha,
-         beta,
-         k},
-        aengine);
+        aengine, prop_kind::forward_training, aalgorithm, src_desc, src_desc,
+        local_size, alpha, beta, k);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aalgorithm, src_desc, diff_dst.get_desc(), local_size, alpha, beta, k},
-        op_attr,
-        aengine,
-        forward_hints);
+        aengine, aalgorithm, diff_dst.get_desc(), diff_dst.get_desc(), src_desc,
+        local_size, alpha, beta, k, forward_hints, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     diff_src.reinit_if_possible(pd.diff_src_desc());

--- a/include/ideep/operators/lstm.hpp
+++ b/include/ideep/operators/lstm.hpp
@@ -53,19 +53,19 @@ struct lstm_forward_inference : public dnnl::lstm_forward {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aprop,
-         direction,
-         src_layer_desc,
-         src_iter_desc,
-         src_iter_c_desc,
-         weights_layer_desc,
-         weights_iter_desc,
-         bias_desc,
-         dst_layer_desc,
-         dst_iter_desc,
-         dst_iter_c_desc},
-        op_attr,
-        aengine);
+        aengine,
+        aprop,
+        direction,
+        src_layer_desc,
+        src_iter_desc,
+        src_iter_c_desc,
+        weights_layer_desc,
+        weights_iter_desc,
+        bias_desc,
+        dst_layer_desc,
+        dst_iter_desc,
+        dst_iter_c_desc,
+        op_attr);
 
     auto expected_weights_layer =
         weights_layer.reorder_if_differ_in(pd.weights_layer_desc(), op_attr);
@@ -126,19 +126,19 @@ struct lstm_forward_inference : public dnnl::lstm_forward {
         output_sizes, src_layer.get_data_type(), tag::tnc);
 
     auto pd = primitive_desc(
-        {aprop,
-         direction,
-         src_layer_desc,
-         src_iter_desc,
-         src_iter_c_desc,
-         weights_layer_desc,
-         weights_iter_desc,
-         bias_desc,
-         dst_layer_desc,
-         src_iter_desc,
-         src_iter_c_desc},
-        op_attr,
-        aengine);
+        aengine,
+        aprop,
+        direction,
+        src_layer_desc,
+        src_iter_desc,
+        src_iter_c_desc,
+        weights_layer_desc,
+        weights_iter_desc,
+        bias_desc,
+        dst_layer_desc,
+        src_iter_desc,
+        src_iter_c_desc,
+        op_attr);
 
     auto expected_weights_layer = pd.weights_layer_desc();
     auto expected_weights_iter = pd.weights_iter_desc();
@@ -183,19 +183,19 @@ struct lstm_forward_training : public dnnl::lstm_forward {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {prop_kind::forward_training,
-         direction,
-         src_layer_desc,
-         src_iter_desc,
-         src_iter_c_desc,
-         weights_layer_desc,
-         weights_iter_desc,
-         bias_desc,
-         dst_layer_desc,
-         dst_iter_desc,
-         dst_iter_c_desc},
-        op_attr,
-        aengine);
+        aengine,
+        prop_kind::forward_training,
+        direction,
+        src_layer_desc,
+        src_iter_desc,
+        src_iter_c_desc,
+        weights_layer_desc,
+        weights_iter_desc,
+        bias_desc,
+        dst_layer_desc,
+        dst_iter_desc,
+        dst_iter_c_desc,
+        op_attr);
     return pd;
   }
 
@@ -265,18 +265,18 @@ struct lstm_forward_training : public dnnl::lstm_forward {
         output_sizes, src_layer.get_data_type(), tag::tnc);
 
     auto pd = primitive_desc(
-        {aprop,
-         direction,
-         src_layer_desc,
-         src_iter_desc,
-         src_iter_c_desc,
-         weights_layer_desc,
-         weights_iter_desc,
-         bias_desc,
-         dst_layer_desc,
-         src_iter_desc,
-         src_iter_c_desc},
-        aengine);
+        aengine,
+        aprop,
+        direction,
+        src_layer_desc,
+        src_iter_desc,
+        src_iter_c_desc,
+        weights_layer_desc,
+        weights_iter_desc,
+        bias_desc,
+        dst_layer_desc,
+        src_iter_desc,
+        src_iter_c_desc);
 
     auto expected_weights_layer = pd.weights_layer_desc();
     auto expected_weights_iter = pd.weights_iter_desc();
@@ -344,29 +344,29 @@ struct lstm_backward : public dnnl::lstm_backward {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {aprop,
-         direction,
-         src_layer_desc,
-         src_iter_desc,
-         src_iter_c_desc,
-         weights_layer_desc,
-         weights_iter_desc,
-         bias_desc,
-         dst_layer_desc,
-         dst_iter_desc,
-         dst_iter_c_desc,
-         diff_src_layer_desc,
-         diff_src_iter_desc,
-         diff_src_iter_c_desc,
-         diff_weights_layer_desc,
-         diff_weights_iter_desc,
-         diff_bias_desc,
-         diff_dst_layer_desc,
-         diff_dst_iter_desc,
-         diff_dst_iter_c_desc},
-        op_attr,
         aengine,
-        forward_hints);
+        aprop,
+        direction,
+        src_layer_desc,
+        src_iter_desc,
+        src_iter_c_desc,
+        weights_layer_desc,
+        weights_iter_desc,
+        bias_desc,
+        dst_layer_desc,
+        dst_iter_desc,
+        dst_iter_c_desc,
+        diff_src_layer_desc,
+        diff_src_iter_desc,
+        diff_src_iter_c_desc,
+        diff_weights_layer_desc,
+        diff_weights_iter_desc,
+        diff_bias_desc,
+        diff_dst_layer_desc,
+        diff_dst_iter_desc,
+        diff_dst_iter_c_desc,
+        forward_hints,
+        op_attr);
 
     auto expected_weights_layer =
         weights_layer.reorder_if_differ_in(pd.weights_layer_desc());

--- a/include/ideep/operators/lstm.hpp
+++ b/include/ideep/operators/lstm.hpp
@@ -37,8 +37,6 @@ struct lstm_forward_inference : public dnnl::lstm_forward {
 
     attr_t op_attr = attr;
     if (src_layer.get_data_type() == data_type::u8) {
-      // weights_layer_desc = weights_layer_desc.to_type(data_type::s8);
-      // weights_iter_desc = weights_iter_desc.to_type(data_type::s8);
       weights_layer_desc = tensor::desc(weights_layer.get_dims(), data_type::s8, tag::any);
       weights_iter_desc = tensor::desc(weights_iter.get_dims(), data_type::s8, tag::any);
 
@@ -116,8 +114,6 @@ struct lstm_forward_inference : public dnnl::lstm_forward {
 
     attr_t op_attr;
     if (src_layer.get_data_type() == data_type::u8) {
-      // weights_layer_desc = weights_layer_desc.to_type(data_type::s8);
-      // weights_iter_desc = weights_iter_desc.to_type(data_type::s8);
       weights_layer_desc = tensor::desc(weights_layer.get_dims(), data_type::s8, tag::any);
       weights_iter_desc = tensor::desc(weights_iter.get_dims(), data_type::s8, tag::any);
 
@@ -336,8 +332,6 @@ struct lstm_backward : public dnnl::lstm_backward {
     auto diff_src_layer_desc = src_layer_desc.to_type(data_type::f32);
     auto diff_src_iter_desc = src_iter_desc.to_type(data_type::f32);
     auto diff_src_iter_c_desc = src_iter_c_desc.to_type(data_type::f32);
-    // auto diff_weights_layer_desc = weights_layer_desc.to_type(data_type::f32);
-    // auto diff_weights_iter_desc = weights_iter_desc.to_type(data_type::f32);
     auto diff_weights_layer_desc = tensor::desc(weights_layer.get_dims(), data_type::f32, tag::any);
     auto diff_weights_iter_desc = tensor::desc(weights_iter.get_dims(), data_type::f32, tag::any);
     auto diff_bias_desc = bias_desc.to_type(data_type::f32);

--- a/include/ideep/operators/lstm.hpp
+++ b/include/ideep/operators/lstm.hpp
@@ -37,8 +37,10 @@ struct lstm_forward_inference : public dnnl::lstm_forward {
 
     attr_t op_attr = attr;
     if (src_layer.get_data_type() == data_type::u8) {
-      weights_layer_desc = weights_layer_desc.to_type(data_type::s8);
-      weights_iter_desc = weights_iter_desc.to_type(data_type::s8);
+      // weights_layer_desc = weights_layer_desc.to_type(data_type::s8);
+      // weights_iter_desc = weights_iter_desc.to_type(data_type::s8);
+      weights_layer_desc = tensor::desc(weights_layer.get_dims(), data_type::s8, tag::any);
+      weights_iter_desc = tensor::desc(weights_iter.get_dims(), data_type::s8, tag::any);
 
       op_attr.set_rnn_data_qparams(scale, zp);
       op_attr.set_rnn_weights_qparams(weights_scale_mask, weights_scales);
@@ -114,8 +116,10 @@ struct lstm_forward_inference : public dnnl::lstm_forward {
 
     attr_t op_attr;
     if (src_layer.get_data_type() == data_type::u8) {
-      weights_layer_desc = weights_layer_desc.to_type(data_type::s8);
-      weights_iter_desc = weights_iter_desc.to_type(data_type::s8);
+      // weights_layer_desc = weights_layer_desc.to_type(data_type::s8);
+      // weights_iter_desc = weights_iter_desc.to_type(data_type::s8);
+      weights_layer_desc = tensor::desc(weights_layer.get_dims(), data_type::s8, tag::any);
+      weights_iter_desc = tensor::desc(weights_iter.get_dims(), data_type::s8, tag::any);
 
       op_attr.set_rnn_data_qparams(scale, zp);
       op_attr.set_rnn_weights_qparams(weights_scale_mask, weights_scales);
@@ -332,8 +336,10 @@ struct lstm_backward : public dnnl::lstm_backward {
     auto diff_src_layer_desc = src_layer_desc.to_type(data_type::f32);
     auto diff_src_iter_desc = src_iter_desc.to_type(data_type::f32);
     auto diff_src_iter_c_desc = src_iter_c_desc.to_type(data_type::f32);
-    auto diff_weights_layer_desc = weights_layer_desc.to_type(data_type::f32);
-    auto diff_weights_iter_desc = weights_iter_desc.to_type(data_type::f32);
+    // auto diff_weights_layer_desc = weights_layer_desc.to_type(data_type::f32);
+    // auto diff_weights_iter_desc = weights_iter_desc.to_type(data_type::f32);
+    auto diff_weights_layer_desc = tensor::desc(weights_layer.get_dims(), data_type::f32, tag::any);
+    auto diff_weights_iter_desc = tensor::desc(weights_iter.get_dims(), data_type::f32, tag::any);
     auto diff_bias_desc = bias_desc.to_type(data_type::f32);
     auto diff_dst_layer_desc = dst_layer_desc.to_type(data_type::f32);
     auto diff_dst_iter_desc = dst_iter_desc.to_type(data_type::f32);

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -809,7 +809,12 @@ struct matmul_forward : public dnnl::matmul,
     dst_data_type = src.get_data_type() == data_type::bf16 ?
                     data_type::bf16 : data_type::f32;
     src_desc = src.get_desc().to_type(dst_data_type);
-    weights_desc = tensor::desc(weights.get_dims(), dst_data_type, tag::any);
+    // For fp32 matmul, weight (2nd input) is usually not in blocked layout
+    // Plain layout runs faster as of oneDNN 3.0
+    // Should use tag::any to query blocked layout if there is perf gain later
+    weights_desc = weights.get_desc().is_plain() ?
+                   weights.get_desc().to_type(dst_data_type) :
+                   tensor::desc(weights.get_dims(), dst_data_type, tag::any);
     if (with_bias) {
       IDEEP_ENFORCE(bias.get_data_type() == data_type::f32 ||
                     bias.get_data_type() == data_type::bf16,

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -671,11 +671,7 @@ struct matmul_forward : public dnnl::matmul,
     tensor::desc x_desc(x_dims, x_dtype, ndims == 2 ? tag::ab : tag::abc);
     tensor::desc y_desc(y_dims, y_dtype, ndims == 2 ? tag::ab : tag::abc);
     tensor::desc weights_desc(weights_dims , dtype, tag::any);
-    attr_t attr;
-    // If runtime src zero point is not set here, slow ref kernel will be used for quantization
-    // TODO: Not sure if this is still needed when zero points are all set at runtime (onednn v3.0)
-    attr.set_zero_points(DNNL_ARG_SRC, /* mask */ 0, {DNNL_RUNTIME_S32_VAL});
-    auto pd = primitive_desc(aengine, x_desc, weights_desc, y_desc, attr);
+    auto pd = primitive_desc(aengine, x_desc, weights_desc, y_desc);
     return pd.weights_desc();
   }
 

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -677,7 +677,7 @@ struct matmul_forward : public dnnl::matmul,
     attr_t attr;
     // If runtime src zero point is not set here, slow ref kernel will be used for quantization
     attr.set_zero_points(DNNL_ARG_SRC, /* mask */ 0, {DNNL_RUNTIME_S32_VAL});
-    auto pd = primitive_desc({x_desc, weights_desc, y_desc}, attr, aengine);
+    auto pd = primitive_desc(aengine, x_desc, weights_desc, y_desc, attr);
     return pd.weights_desc();
   }
 
@@ -844,10 +844,10 @@ struct matmul_forward : public dnnl::matmul,
     param.pd = fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(
-            {src_desc, weights_desc, bias_desc, dst_desc}, op_attr, aengine);
+            aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
       } else {
         return primitive_desc(
-            {src_desc, weights_desc, dst_desc}, op_attr, aengine);
+            aengine, src_desc, weights_desc, dst_desc, op_attr);
       }
     });
     param.primitive = std::move(super(param.pd));
@@ -996,10 +996,10 @@ struct matmul_forward : public dnnl::matmul,
     param.pd = fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(
-            {src_desc, weights_desc, bias_desc, dst_desc}, op_attr, aengine);
+            aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
       } else {
         return primitive_desc(
-            {src_desc, weights_desc, dst_desc}, op_attr, aengine);
+            aengine, src_desc, weights_desc, dst_desc, op_attr);
       }
     });
     param.primitive = std::move(super(param.pd));
@@ -1103,7 +1103,7 @@ struct matmul_forward : public dnnl::matmul,
     }
 
     // Create pd and primitive
-    param.pd = primitive_desc({src_desc, weights.get_desc(), dst_desc}, op_attr, aengine);
+    param.pd = primitive_desc(aengine, src_desc, weights.get_desc(), dst_desc, op_attr);
     param.primitive = super(param.pd);
 
     // Create src reorder primitive with runtime scales/zero point

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -806,7 +806,8 @@ struct matmul_forward : public dnnl::matmul,
     dst_data_type = src.get_data_type() == data_type::bf16 ?
                     data_type::bf16 : data_type::f32;
     src_desc = src.get_desc().to_type(dst_data_type);
-    weights_desc = weights.get_desc().to_type(dst_data_type);
+    // weights_desc = weights.get_desc().to_type(dst_data_type);
+    weights_desc = tensor::desc(weights.get_dims(), dst_data_type, tag::any);
     if (with_bias) {
       IDEEP_ENFORCE(bias.get_data_type() == data_type::f32 ||
                     bias.get_data_type() == data_type::bf16,

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -916,7 +916,7 @@ struct matmul_forward : public dnnl::matmul,
         std::vector<int64_t>({src_dims[1], 1});
     src_desc = tensor::desc(src_dims, src_data_type, tag::any);
     if (src.get_data_type() == data_type::f32) {
-      src_attr = {0, src_scales_in};
+      src_attr.set_scales(DNNL_ARG_DST, /* mask */ 0, src_scales_in);
     }
 
     int scale_size = (weights_scales_in.size() > 1) ? weights.get_dim(1) : 1;
@@ -1350,7 +1350,7 @@ struct matmul_forward : public dnnl::matmul,
     exec_args args;
     args.insert({DNNL_ARG_SRC, expected_src});
     args.insert({DNNL_ARG_WEIGHTS, expected_weights});
-    args.insert({DNNL_ARG_WEIGHTS, expected_dst});
+    args.insert({DNNL_ARG_DST, expected_dst});
     args.insert({DNNL_ARG_SCRATCHPAD, scratchpad});
     if (with_bias) {
       args.insert({DNNL_ARG_BIAS, bias});
@@ -1369,8 +1369,10 @@ struct matmul_forward : public dnnl::matmul,
         args.insert({DNNL_ARG_ATTR_ZERO_POINTS | dnnl_arg, zp_m});
       }
     }
+    // Src scales and zero point are obtained at runtime thus set separately
     args.insert({DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, src_scales_m});
     args.insert({DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m});
+
     primitive.execute(stream::default_stream(), args);
   }
 

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -915,6 +915,9 @@ struct matmul_forward : public dnnl::matmul,
         std::vector<int64_t>({src_dims[1] * src_dims[2], src_dims[1], 1}) :
         std::vector<int64_t>({src_dims[1], 1});
     src_desc = tensor::desc(src_dims, src_data_type, tag::any);
+    for (auto& s : src_scales_in) {
+      s = 1.0 / s;
+    }
     if (src.get_data_type() == data_type::f32) {
       src_attr.set_scales(DNNL_ARG_DST, /* mask */ 0, src_scales_in);
     }
@@ -956,9 +959,6 @@ struct matmul_forward : public dnnl::matmul,
       op_attr = attr_t::fuse_sum(sum_scale);
     }
 
-    for (auto& s : src_scales_in) {
-      s = 1.0 / s;
-    }
     op_attr.set_scales(DNNL_ARG_SRC, utils::op_scale_mask(src_scales_in.size()), src_scales_in);
     auto wei_scales = weights_scales_in;
     for (auto& s : wei_scales) {

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -1076,10 +1076,10 @@ struct matmul_forward : public dnnl::matmul,
         // User should prepare all post-ops in argument 'attr'.
         new_pops.append_sum(sum_coeff);
       } else if (kind::eltwise == pops.kind(i)) {
-        float scale = 1.0, alpha = 1.0, beta = 0.0;
+        float alpha = 1.0, beta = 0.0;
         dnnl::algorithm alg;
-        pops.get_params_eltwise(i, scale, alg, alpha, beta);
-        new_pops.append_eltwise(scale, alg, alpha, beta);
+        pops.get_params_eltwise(i, alg, alpha, beta);
+        new_pops.append_eltwise(alg, alpha, beta);
       }
     }
     op_attr.set_post_ops(new_pops);

--- a/include/ideep/operators/prelu.hpp
+++ b/include/ideep/operators/prelu.hpp
@@ -30,7 +30,7 @@ struct prelu_forward : public dnnl::prelu_forward {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd =
-        primitive_desc({aprop_kind, src_desc, weight_desc}, op_attr, aengine);
+        primitive_desc(aengine, aprop_kind, src_desc, weight_desc, src_desc, op_attr);
     auto expected_weights = weight_in.reorder_if_differ_in(pd.weights_desc());
     dst.reinit_if_possible(pd.dst_desc());
 
@@ -77,16 +77,14 @@ struct prelu_backward : public dnnl::prelu_backward {
             weight_in.get_dims(), diff_dst_in.get_data_type(), tag::any)
             .to_format_any();
     auto forward_hints = prelu_forward::primitive_desc(
-        {prop_kind::forward, src_desc, weight_desc}, aengine);
+        aengine, prop_kind::forward, src_desc, weight_desc, src_desc);
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto pd = primitive_desc(
-        {src_desc, weight_desc, diff_dst_desc, diff_weights_desc},
-        op_attr,
-        aengine,
-        forward_hints);
+        aengine, src_desc, weight_desc, diff_dst_desc, diff_weights_desc, diff_dst_desc,
+        forward_hints, op_attr);
 
     auto expected_diff_dst =
         diff_dst_in.reorder_if_differ_in(pd.diff_dst_desc());

--- a/include/ideep/operators/sum.hpp
+++ b/include/ideep/operators/sum.hpp
@@ -19,7 +19,6 @@ struct sum : public dnnl::sum {
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    // auto pd = primitive_desc(scales, src_descs, aengine, op_attr);
     auto pd = primitive_desc(aengine, scales, src_descs, op_attr);
 
     dst.reinit_if_possible(pd.dst_desc());

--- a/include/ideep/operators/sum.hpp
+++ b/include/ideep/operators/sum.hpp
@@ -19,7 +19,8 @@ struct sum : public dnnl::sum {
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    auto pd = primitive_desc(scales, src_descs, aengine, op_attr);
+    // auto pd = primitive_desc(scales, src_descs, aengine, op_attr);
+    auto pd = primitive_desc(aengine, scales, src_descs, op_attr);
 
     dst.reinit_if_possible(pd.dst_desc());
     tensor scratchpad(pd.scratchpad_desc());

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -803,7 +803,7 @@ class tensor : public memory {
     zero_point_ = std::move(t.zero_point_);
     workspace_ = std::move(t.workspace_);
     eng_ = std::move(t.eng_);
-    groups_ = t.groups_;
+    groups_ = std::move(t.groups_);
     return *this;
   }
 

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -10,11 +10,12 @@ class tensor : public memory {
  public:
   using dim_t = dnnl_dim_t;
   using dims_t = dnnl_dims_t;
-  using format_kind_t = dnnl_format_kind_t;
-  using blocking_desc_t = dnnl_blocking_desc_t;
+  using format_kind_t = memory::format_kind;
+  // using blocking_desc_t = dnnl_blocking_desc_t;
   using descriptor = tensor::desc; // for backward compatibility
 
   struct desc : public memory::desc {
+    using super = memory::desc;
     friend class tensor;
 
     // avoid conflicts with function desc::dims() and desc::data_type()
@@ -24,12 +25,12 @@ class tensor : public memory {
     desc() : memory::desc(){};
 
     // copy ctor
-    desc(const desc& adesc) : memory::desc(adesc.data) {
+    desc(const desc& adesc) : memory::desc(adesc.get()) {
       set_g(adesc.g());
     };
 
     // supplement group info for memory::desc
-    desc(const memory::desc& adesc, dim groups = 1) : memory::desc(adesc.data) {
+    desc(const memory::desc& adesc, dim groups = 1) : memory::desc(adesc.get()) {
       set_g(groups);
     };
 
@@ -54,96 +55,114 @@ class tensor : public memory {
       set_g(1);
     }
 
+    // internal ndims
+    inline int get_internal_ndims() const {
+      return memory::desc::get_ndims();
+    }
+
+    // internal dims
+    inline dims get_internal_dims() const {
+      return memory::desc::get_dims();
+    }
+
+    // internal strides
+    inline dims get_internal_strides() const {
+      return memory::desc::get_strides();
+    }
+
     void to_bytes(utils::bytestring& bytes) const {
       utils::to_bytes(bytes, get_data_type());
       utils::to_bytes(bytes, format_kind());
-      utils::to_bytes(bytes, offset0());
+      utils::to_bytes(bytes, get_submemory_offset() /* offset0() */);
 
-      auto& paddim = padded_dims();
-      auto& padoff = padded_offsets();
+      auto paddim = get_padded_dims(); // padded_dims();
+      auto padoff = get_padded_offsets(); // padded_offsets();
 
-      for (int i = 0; i < data.ndims; i++) {
-        utils::to_bytes(bytes, data.dims[i]);
+      for (int i = 0; i < get_internal_ndims(); i++) {
+        utils::to_bytes(bytes, get_internal_dims()[i]);
         utils::to_bytes(bytes, paddim[i]);
         utils::to_bytes(bytes, padoff[i]);
       }
 
       if (is_blocking_desc()) {
-        auto& blk = blocking_desc();
-        auto& stride = blocking_strides();
-        for (int i = 0; i < data.ndims; i++) {
+        auto stride = get_internal_strides(); // blocking_strides();
+        for (int i = 0; i < get_internal_ndims(); i++) {
           utils::to_bytes(bytes, stride[i]);
         }
-        for (int i = 0; i < blk.inner_nblks; i++) {
-          utils::to_bytes(bytes, blk.inner_idxs[i]);
-          utils::to_bytes(bytes, blk.inner_blks[i]);
+        for (int i = 0; i < get_inner_nblks(); i++) {
+          utils::to_bytes(bytes, get_inner_idxs()[i]);
+          utils::to_bytes(bytes, get_inner_blks()[i]);
         }
       }
     }
 
     /// public ndims
     inline int get_ndims() const {
-      return is_grouped() ? data.ndims - 1 : data.ndims;
+      return is_grouped() ? get_internal_ndims() - 1 : get_internal_ndims();
     }
 
     /// Return size of specified dimension
     inline dim_t get_dim(int index) const {
       if (!is_grouped()) {
-        if (index < 0 || index >= data.ndims)
+        if (index < 0 || index >= get_internal_ndims())
           return static_cast<dim_t>(0);
-        return data.dims[index];
+        return get_internal_dims()[index];
       } else {
-        if (index < 0 || index >= data.ndims - 1)
+        if (index < 0 || index >= get_internal_ndims() - 1)
           return static_cast<dim_t>(0);
-        return index == 0 ? data.dims[0] * data.dims[1] : data.dims[index + 1];
+        return index == 0 ?
+            get_internal_dims()[0] * get_internal_dims()[1] :
+            get_internal_dims()[index + 1];
       }
     }
 
     /// Returns dimension vector
     inline dims get_dims() const {
       if (!is_grouped()) {
-        return dims(data.dims, data.dims + data.ndims);
+        return get_internal_dims();
       } else {
-        auto ret = dims(data.dims + 1, data.dims + data.ndims);
-        ret[0] *= data.dims[0]; // g == data.dims[0]
+        auto orig_dims = get_internal_dims();
+        auto ret = dims(orig_dims.begin() + 1, orig_dims.end());
+        ret[0] *= orig_dims[0]; // g == data.dims[0]
         return ret;
       }
     }
 
     /// Returns descriptor data type
-    inline data_type get_data_type() const {
-      return static_cast<data_type>(data.data_type);
-    }
+    // inline data_type get_data_type() const {
+    //   return static_cast<data_type>(data.data_type);
+    // }
 
     inline dims get_strides() const {
       IDEEP_ENFORCE(is_plain(), "Call to_public() before get_strides()");
-      const auto& strides = blocking_strides();
+      // const auto& strides = blocking_strides();
       if (!is_grouped()) {
-        return dims(strides, strides + data.ndims);
+        return get_internal_strides();
       } else {
-        auto ret = dims(strides + 1, strides + data.ndims);
+        auto strides = get_internal_strides();
+        auto ret = dims(strides.begin() + 1, strides.end());
         ret[0] = std::min(strides[0], strides[1]);
         return ret;
       }
     }
 
     /** returns true if memory descriptor is zero */
-    bool is_zero() const {
-      return data.ndims == 0;
-    }
+    // bool is_zero() const {
+    //   return data.ndims == 0;
+    // }
 
     /** returns the number of elements including padding if \param with_padding
      * is true, and the number of data elements otherwise */
     inline dim_t nelems(bool with_padding = false) const {
       if (is_zero())
         return 0;
-      auto dims = with_padding ? data.padded_dims : data.dims;
+      auto dims = with_padding ? get_padded_dims() : get_internal_dims();
       return std::accumulate(
-          dims, dims + data.ndims, 1, std::multiplies<dim_t>());
+          dims.begin(), dims.end(), 1, std::multiplies<dim_t>());
     }
 
     inline bool is_plain() const {
-      return is_blocking_desc() && blocking_desc().inner_nblks == 0;
+      return is_blocking_desc() && get_inner_nblks() == 0;
     };
 
     inline bool is_rnn_packed() const {
@@ -154,8 +173,8 @@ class tensor : public memory {
       if (!is_plain())
         return false;
 
-      const auto& strides = blocking_strides();
-      for (int i = 0; i < data.ndims - 1; i++) {
+      const auto& strides = get_internal_strides(); // blocking_strides();
+      for (int i = 0; i < get_internal_ndims() - 1; i++) {
         if (strides[i] < strides[i + 1]) {
           return false;
         }
@@ -167,9 +186,9 @@ class tensor : public memory {
     // It may cause error in edge cases.
     // Avoid using it to determine memory layout in PyTorch.
     inline bool is_nhwc() const {
-      if (!is_plain() || data.ndims != 4) return false;
-      const auto &dims = data.dims;
-      const auto &strides = blocking_strides();
+      if (!is_plain() || get_internal_ndims() != 4) return false;
+      const auto &dims = get_internal_dims();
+      const auto &strides = get_internal_strides(); // blocking_strides();
       const auto n = 0, c = 1, h = 2, w = 3;
       return strides[n] == dims[h] * dims[w] * dims[c]
           && strides[h] == dims[w] * dims[c]
@@ -181,9 +200,9 @@ class tensor : public memory {
     // It may cause error in edge cases.
     // Avoid using it to determine memory layout in PyTorch.
     inline bool is_ndhwc() const {
-      if (!is_plain() || data.ndims != 5) return false;
-      const auto &dims = data.dims;
-      const auto &strides = blocking_strides();
+      if (!is_plain() || get_internal_ndims() != 5) return false;
+      const auto &dims = get_internal_dims();
+      const auto &strides = get_internal_strides(); // blocking_strides();
       const auto n = 0, c = 1, d =2, h = 3, w = 4;
       return strides[n] == dims[d] * dims[h] * dims[w] * dims[c]
           && strides[d] == dims[h] * dims[w] * dims[c]
@@ -193,10 +212,10 @@ class tensor : public memory {
     }
 
     inline bool is_nchw() const {
-      if (!is_plain() || data.ndims != 4)
+      if (!is_plain() || get_internal_ndims() != 4)
         return false;
-      const auto& dims = data.dims;
-      const auto& strides = blocking_strides();
+      const auto& dims = get_internal_dims();
+      const auto& strides = get_internal_strides(); // blocking_strides();
       const auto n = 0, c = 1, h = 2, w = 3;
       return strides[n] == dims[c] * dims[h] * dims[w] &&
           strides[c] == dims[h] * dims[w] && strides[h] == dims[w] &&
@@ -204,17 +223,18 @@ class tensor : public memory {
     };
 
     inline bool is_channels_last() const {
+      auto ndims = get_internal_ndims();
       if (!is_plain() ||
-          !(data.ndims == 4 || data.ndims == 5 || data.ndims == 3))
+          !(ndims == 4 || ndims == 5 || ndims == 3))
         return false;
-      const auto& dims = data.dims;
-      const auto& strides = blocking_strides();
-      if (data.ndims == 4) {
+      const auto& dims = get_internal_dims();
+      const auto& strides = get_internal_strides(); // blocking_strides();
+      if (ndims == 4) {
         const auto n = 0, c = 1, h = 2, w = 3;
         return strides[n] == dims[h] * dims[w] * dims[c] &&
             strides[h] == dims[w] * dims[c] && strides[w] == dims[c] &&
             strides[c] == 1;
-      } else if (data.ndims == 5) {
+      } else if (ndims == 5) {
         const auto n = 0, c = 1, d = 2, h = 3, w = 4;
         return strides[n] == dims[d] * dims[h] * dims[w] * dims[c] &&
             strides[d] == dims[h] * dims[w] * dims[c] &&
@@ -228,10 +248,10 @@ class tensor : public memory {
     };
 
     inline bool is_iohw() const {
-      if (!is_plain() || data.ndims != 4)
+      if (!is_plain() || get_internal_ndims() != 4)
         return false;
-      const auto& dims = data.dims;
-      const auto& strides = blocking_strides();
+      const auto& dims = get_internal_dims();
+      const auto& strides = get_internal_strides(); // blocking_strides();
       const auto o = 0, i = 1, h = 2, w = 3;
       return strides[i] == dims[o] * dims[h] * dims[w] &&
           strides[o] == dims[h] * dims[w] && strides[h] == dims[w] &&
@@ -240,23 +260,22 @@ class tensor : public memory {
 
     // workaround for issue intel/mkl-dnn#588
     bool is_4c_blocked() {
-      const auto& blk = blocking_desc();
-      return blk.inner_nblks == 1 && blk.inner_idxs[0] == 1 &&
-          blk.inner_blks[0] == 4;
+      return get_inner_nblks() == 1 && get_inner_idxs()[0] == 1 &&
+          get_inner_blks()[0] == 4;
     }
 
     // legacy API for caffe2
     bool is_limited_blockable() const {
-      const auto& blk = blocking_desc();
       // compute compatible block_dims with v0.x
-      dims block_dims(data.ndims, 1);
-      for (auto i = 0; i < blk.inner_nblks; i++) {
-        block_dims[blk.inner_idxs[i]] *= blk.inner_blks[i];
+      dims block_dims(get_internal_ndims(), 1);
+      for (auto i = 0; i < get_inner_nblks(); i++) {
+        block_dims[get_inner_idxs()[i]] *= get_inner_blks()[i];
       }
-      for (auto i = 0; i < data.ndims; i++) {
-        if (data.dims[i] < block_dims[i])
+      auto desc_dims = get_internal_dims();
+      for (auto i = 0; i < get_internal_ndims(); i++) {
+        if (desc_dims[i] < block_dims[i])
           continue;
-        if (data.dims[i] % block_dims[i] == 0)
+        if (desc_dims[i] % block_dims[i] == 0)
           continue;
         return false;
       }
@@ -286,8 +305,10 @@ class tensor : public memory {
     }
 
     desc to_type(data_type atype) const {
-      auto ret = clone();
-      ret.data.data_type = static_cast<dnnl_data_type_t>(atype);
+      // auto ret = clone();
+      // ret.data.data_type = static_cast<dnnl_data_type_t>(atype);
+      auto md = memory::desc(get_internal_dims(), atype, get_internal_strides());
+      desc ret(md);
       ret.set_g(g());
       return ret;
     }
@@ -300,79 +321,81 @@ class tensor : public memory {
     }
 
     bool has_same_shape_as(const desc& that) const {
-      if (data.ndims != that.data.ndims)
+      if (get_internal_ndims() != that.get_internal_ndims())
         return false;
-      return utils::array_cmp(data.dims, that.data.dims, data.ndims);
+      return get_internal_dims() == that.get_internal_dims();
     }
 
     // to be replaced with memory_desc_permute_axes in DNNL v1.3
     desc permute(const std::vector<int>& permute_axes = {}) const {
-      if (data.ndims <= 1) {
-        return clone();
-      }
+      auto permuted_md = super::permute_axes(permute_axes);
+      return desc(permuted_md);
+      // if (data.ndims <= 1) {
+      //   return clone();
+      // }
 
-      auto perms = permute_axes;
-      if (perms.empty()) {
-        perms.resize(data.ndims);
-        std::iota(perms.rbegin(), perms.rend(), 0);
-      } else {
-        IDEEP_ENFORCE(
-            perms.size() == data.ndims,
-            "Axes should be size like source tensor.");
-        auto perms_sorted = perms;
-        std::sort(perms_sorted.begin(), perms_sorted.end());
-        for (auto i = 0; i < perms_sorted.size(); ++i) {
-          IDEEP_ENFORCE(
-              perms_sorted[i] == i,
-              "Axes should be a permutation of 0 to ndim.");
-        }
-        if (perms_sorted == perms) {
-          return clone();
-        }
-      }
+      // auto perms = permute_axes;
+      // if (perms.empty()) {
+      //   perms.resize(data.ndims);
+      //   std::iota(perms.rbegin(), perms.rend(), 0);
+      // } else {
+      //   IDEEP_ENFORCE(
+      //       perms.size() == data.ndims,
+      //       "Axes should be size like source tensor.");
+      //   auto perms_sorted = perms;
+      //   std::sort(perms_sorted.begin(), perms_sorted.end());
+      //   for (auto i = 0; i < perms_sorted.size(); ++i) {
+      //     IDEEP_ENFORCE(
+      //         perms_sorted[i] == i,
+      //         "Axes should be a permutation of 0 to ndim.");
+      //   }
+      //   if (perms_sorted == perms) {
+      //     return clone();
+      //   }
+      // }
 
-      desc new_desc{};
-      auto ndims = data.ndims;
-      new_desc.data.ndims = data.ndims;
-      new_desc.data.data_type = data.data_type;
-      new_desc.data.format_kind = data.format_kind;
-      new_desc.data.offset0 = data.offset0;
-      new_desc.set_g(g());
+      // desc new_desc{};
+      // auto ndims = data.ndims;
+      // new_desc.data.ndims = data.ndims;
+      // new_desc.data.data_type = data.data_type;
+      // new_desc.data.format_kind = data.format_kind;
+      // new_desc.data.offset0 = data.offset0;
+      // new_desc.set_g(g());
 
-      // permute dims, padded_dims, padded_offsets, strides
-      auto& new_dims = new_desc.data.dims;
-      auto& old_dims = data.dims;
-      auto& new_stride = new_desc.data.format_desc.blocking.strides;
-      auto& old_stride = data.format_desc.blocking.strides;
-      auto& new_paddim = new_desc.data.padded_dims;
-      auto& old_paddim = data.padded_dims;
-      auto& new_padoff = new_desc.data.padded_offsets;
-      auto& old_padoff = data.padded_offsets;
-      for (int i = 0; i < ndims; i++) {
-        new_dims[i] = old_dims[perms[i]];
-        new_stride[i] = old_stride[perms[i]];
-        new_paddim[i] = old_paddim[perms[i]];
-        new_padoff[i] = old_padoff[perms[i]];
-      }
+      // // permute dims, padded_dims, padded_offsets, strides
+      // auto& new_dims = new_desc.data.dims;
+      // auto& old_dims = data.dims;
+      // auto& new_stride = new_desc.data.format_desc.blocking.strides;
+      // auto& old_stride = data.format_desc.blocking.strides;
+      // auto& new_paddim = new_desc.data.padded_dims;
+      // auto& old_paddim = data.padded_dims;
+      // auto& new_padoff = new_desc.data.padded_offsets;
+      // auto& old_padoff = data.padded_offsets;
+      // for (int i = 0; i < ndims; i++) {
+      //   new_dims[i] = old_dims[perms[i]];
+      //   new_stride[i] = old_stride[perms[i]];
+      //   new_paddim[i] = old_paddim[perms[i]];
+      //   new_padoff[i] = old_padoff[perms[i]];
+      // }
 
-      // permute blocking
-      auto inner_nblks = data.format_desc.blocking.inner_nblks;
-      new_desc.data.format_desc.blocking.inner_nblks = inner_nblks;
-      auto& old_inner_idxs = data.format_desc.blocking.inner_idxs;
-      auto& new_inner_idxs = new_desc.data.format_desc.blocking.inner_idxs;
-      auto& old_inner_blks = data.format_desc.blocking.inner_blks;
-      auto& new_inner_blks = new_desc.data.format_desc.blocking.inner_blks;
-      for (int i = 0; i < inner_nblks; i++) {
-        new_inner_idxs[i] = perms[old_inner_idxs[i]];
-        new_inner_blks[i] = old_inner_blks[i];
-      }
-      new_desc.data.extra = data.extra;
+      // // permute blocking
+      // auto inner_nblks = data.format_desc.blocking.inner_nblks;
+      // new_desc.data.format_desc.blocking.inner_nblks = inner_nblks;
+      // auto& old_inner_idxs = data.format_desc.blocking.inner_idxs;
+      // auto& new_inner_idxs = new_desc.data.format_desc.blocking.inner_idxs;
+      // auto& old_inner_blks = data.format_desc.blocking.inner_blks;
+      // auto& new_inner_blks = new_desc.data.format_desc.blocking.inner_blks;
+      // for (int i = 0; i < inner_nblks; i++) {
+      //   new_inner_idxs[i] = perms[old_inner_idxs[i]];
+      //   new_inner_blks[i] = old_inner_blks[i];
+      // }
+      // new_desc.data.extra = data.extra;
 
-      return new_desc;
+      // return new_desc;
     }
 
     desc transpose(dim dim0, dim dim1) const {
-      std::vector<int> axes(data.ndims);
+      std::vector<int> axes(get_internal_ndims());
       std::iota(axes.begin(), axes.end(), 0);
       std::swap(axes[dim0], axes[dim1]);
       return permute(axes);
@@ -382,130 +405,142 @@ class tensor : public memory {
      * blocking structure
      */
     desc to_dims(const dims& adims) const {
-      IDEEP_ENFORCE(adims.size() == data.ndims, "Rank mismatched.");
+      IDEEP_ENFORCE(adims.size() == get_internal_ndims(), "Rank mismatched.");
+      return desc(super::reshape(adims));
 
-      dnnl_memory_desc_t md;
-      md.ndims = data.ndims;
-      md.data_type = data.data_type;
+      // dnnl_memory_desc_t md;
+      // md.ndims = data.ndims;
+      // md.data_type = data.data_type;
 
-      auto& blk = blocking_desc();
+      // auto& blk = blocking_desc();
 
-      dims_t blocks;
-      for (auto i = 0; i < data.ndims; i++)
-        blocks[i] = 1;
+      // dims_t blocks;
+      // for (auto i = 0; i < data.ndims; i++)
+      //   blocks[i] = 1;
 
-      dim_t block_size = 1;
-      for (int iblk = 0; iblk < blk.inner_nblks; ++iblk) {
-        blocks[blk.inner_idxs[iblk]] *= blk.inner_blks[iblk];
-        block_size *= blk.inner_blks[iblk];
-      }
+      // dim_t block_size = 1;
+      // for (int iblk = 0; iblk < blk.inner_nblks; ++iblk) {
+      //   blocks[blk.inner_idxs[iblk]] *= blk.inner_blks[iblk];
+      //   block_size *= blk.inner_blks[iblk];
+      // }
 
-      for (int d = 0; d < data.ndims; ++d) {
-        md.dims[d] = adims[d];
-        md.padded_dims[d] = utils::rnd_up(adims[d], blocks[d]);
-        md.padded_offsets[d] = 0;
-      }
-      md.offset0 = 0;
+      // for (int d = 0; d < data.ndims; ++d) {
+      //   md.dims[d] = adims[d];
+      //   md.padded_dims[d] = utils::rnd_up(adims[d], blocks[d]);
+      //   md.padded_offsets[d] = 0;
+      // }
+      // md.offset0 = 0;
 
-      md.format_kind = dnnl_blocked;
-      auto& mblk = md.format_desc.blocking;
-      mblk = blk;
+      // md.format_kind = dnnl_blocked;
+      // auto& mblk = md.format_desc.blocking;
+      // mblk = blk;
 
-      for (auto i = 0; i < data.ndims; i++)
-        mblk.strides[i] = blk.strides[i];
+      // for (auto i = 0; i < data.ndims; i++)
+      //   mblk.strides[i] = blk.strides[i];
 
-      int perm[DNNL_MAX_NDIMS];
-      for (int d = 0; d < data.ndims; ++d)
-        perm[d] = d;
+      // int perm[DNNL_MAX_NDIMS];
+      // for (int d = 0; d < data.ndims; ++d)
+      //   perm[d] = d;
 
-      utils::simultaneous_sort(
-          mblk.strides, perm, data.ndims, [](dim_t a, dim_t b) {
-            return b - a;
-          });
+      // utils::simultaneous_sort(
+      //     mblk.strides, perm, data.ndims, [](dim_t a, dim_t b) {
+      //       return b - a;
+      //     });
 
-      dim_t stride = block_size;
-      for (int _d = data.ndims - 1; _d >= 0; --_d) {
-        const int d = perm[_d];
-        md.format_desc.blocking.strides[d] = stride;
-        stride *= md.padded_dims[d] / blocks[d];
-      }
+      // dim_t stride = block_size;
+      // for (int _d = data.ndims - 1; _d >= 0; --_d) {
+      //   const int d = perm[_d];
+      //   md.format_desc.blocking.strides[d] = stride;
+      //   stride *= md.padded_dims[d] / blocks[d];
+      // }
 
-      md.extra = dnnl_memory_extra_desc_t{};
+      // md.extra = dnnl_memory_extra_desc_t{};
 
-      return desc(md);
+      // return desc(md);
     }
 
-    const blocking_desc_t& blocking_desc() const {
-      IDEEP_ENFORCE(
-          is_blocking_desc(),
-          "Cannot get blocking desc on a non-blocking desc");
-      return data.format_desc.blocking;
-    }
+    // const blocking_desc_t& blocking_desc() const {
+    //   IDEEP_ENFORCE(
+    //       is_blocking_desc(),
+    //       "Cannot get blocking desc on a non-blocking desc");
+    //   return data.format_desc.blocking;
+    // }
 
-    dims_t& blocking_strides() const {
-      IDEEP_ENFORCE(
-          is_blocking_desc(),
-          "Cannot get blocking desc on a non-blocking desc");
-      return const_cast<dnnl_memory_desc_t&>(data).format_desc.blocking.strides;
-    }
+    // dims_t& blocking_strides() const {
+    //   IDEEP_ENFORCE(
+    //       is_blocking_desc(),
+    //       "Cannot get blocking desc on a non-blocking desc");
+    //   return const_cast<dnnl_memory_desc_t&>(data).format_desc.blocking.strides;
+    // }
 
-    const dims_t& padded_dims() const {
-      return data.padded_dims;
-    }
+    // const dims_t& padded_dims() const {
+      // return data.padded_dims;
+    // }
 
    private:
     /// Returns dimension vector
-    inline dims get_internal_dims() const {
-      return dims(data.dims, data.dims + data.ndims);
-    }
+    // inline dims get_internal_dims() const {
+    //   return dims(data.dims, data.dims + data.ndims);
+    // }
 
-    const dims_t& padded_offsets() const {
-      return data.padded_offsets;
-    }
+    // const dims_t& padded_offsets() const {
+    //   return data.padded_offsets;
+    // }
 
-    dim_t offset0() const {
-      return data.offset0;
-    }
+    // dim_t offset0() const {
+    //   return data.offset0;
+    // }
 
-    inline format_kind_t format_kind() const {
-      return data.format_kind;
-    }
+    // inline format_kind_t format_kind() const {
+    //   return data.format_kind;
+    // }
 
     bool is_blocking_desc() const {
-      return format_kind() == dnnl_blocked;
+      return get_format_kind() == format_kind::blocked;
     }
 
+    // Deprecated. Not used in PyTorch.
     bool is_wino_desc() const {
-      return format_kind() == dnnl_format_kind_wino;
+      return get_format_kind() == dnnl_format_kind_wino;
     }
 
     bool is_rnn_packed_desc() const {
-      return format_kind() == dnnl_format_kind_rnn_packed;
+      return get_format_kind() == dnnl_format_kind_rnn_packed;
     }
 
     void set_g(dim groups) {
-      auto reserved_size = sizeof(((dnnl_memory_extra_desc_t*)0)->reserved);
-      auto offset = reserved_size / sizeof(dim) - 1;
-      reinterpret_cast<dim*>(data.extra.reserved)[offset] = groups;
+      // auto reserved_size = sizeof(((dnnl_memory_extra_desc_t*)0)->reserved);
+      // auto offset = reserved_size / sizeof(dim) - 1;
+      // reinterpret_cast<dim*>(data.extra.reserved)[offset] = groups;
+      this->groups = groups;
     }
 
     dim g() const {
-      auto reserved_size = sizeof(((dnnl_memory_extra_desc_t*)0)->reserved);
-      auto offset = reserved_size / sizeof(dim) - 1;
-      return reinterpret_cast<const dim*>(data.extra.reserved)[offset];
+      // auto reserved_size = sizeof(((dnnl_memory_extra_desc_t*)0)->reserved);
+      // auto offset = reserved_size / sizeof(dim) - 1;
+      // return reinterpret_cast<const dim*>(data.extra.reserved)[offset];
+      return groups;
     }
 
     inline bool is_grouped() const {
       return g() > 1;
     }
+
+    int groups = 1;
+    // The following two formats are now internal only in oneDNN
+    // Copy them here for compatibility
+    static const format_kind_t internal_only_start = (format_kind_t)(1 << 8);
+    static const format_kind_t dnnl_format_kind_wino = internal_only_start;
+    static const format_kind_t dnnl_format_kind_rnn_packed = (format_kind_t)((int)internal_only_start + 1);
   };
 
   desc get_desc() const {
-    const dnnl_memory_desc_t* cdesc;
-    error::wrap_c_api(
-        dnnl_memory_get_memory_desc(get(), &cdesc),
-        "could not get memory descriptor from a memory");
-    return desc(*cdesc);
+    // const dnnl_memory_desc_t* cdesc;
+    // error::wrap_c_api(
+    //     dnnl_memory_get_memory_desc(get(), &cdesc),
+    //     "could not get memory descriptor from a memory");
+    // return desc(*cdesc);
+    return desc(memory::get_desc());
   }
 
   // For backward compatibility. Will be deprecated.
@@ -945,9 +980,9 @@ class tensor : public memory {
             return false;
           // block format, only one dim is blocked, and the size of blocked dim
           // > 1.
-          auto block_desc = src_desc.blocking_desc();
-          if (block_desc.inner_nblks == 1 &&
-              shape[block_desc.inner_idxs[0]] > 1) {
+          // auto block_desc = src_desc.blocking_desc();
+          if (src_desc.get_inner_nblks() == 1 &&
+              shape[src_desc.get_inner_idxs()[0]] > 1) {
             return false;
           }
         }
@@ -1225,11 +1260,13 @@ class tensor : public memory {
 
  private:
   void reset_internal(const desc& adesc, const engine& aengine, void* ahandle) {
-    dnnl_memory_t result;
-    error::wrap_c_api(
-        dnnl_memory_create(&result, &adesc.data, aengine.get(), ahandle),
-        "could not create a memory");
-    reset(result);
+    // dnnl_memory_t result;
+    // error::wrap_c_api(
+    //     dnnl_memory_create(&result, &adesc.data, aengine.get(), ahandle),
+    //     "could not create a memory");
+    // reset(result);
+    memory result(adesc, aengine, ahandle);
+    reset(result.get());
   }
 
   inline void to_format(const desc& adesc) {

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -11,7 +11,6 @@ class tensor : public memory {
   using dim_t = dnnl_dim_t;
   using dims_t = dnnl_dims_t;
   using format_kind_t = memory::format_kind;
-  // using blocking_desc_t = dnnl_blocking_desc_t;
   using descriptor = tensor::desc; // for backward compatibility
 
   struct desc : public memory::desc {
@@ -123,7 +122,6 @@ class tensor : public memory {
 
     inline dims get_strides() const {
       IDEEP_ENFORCE(is_plain(), "Call to_public() before get_strides()");
-      // const auto& strides = blocking_strides();
       dim_t *strides = nullptr;
       dnnl_memory_desc_query(get(), dnnl_query_strides, &strides);
       if (!is_grouped()) {

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -3,6 +3,7 @@
 
 #include "attributes.hpp"
 #include "utils.hpp"
+#include <iostream>
 
 namespace ideep {
 
@@ -967,6 +968,7 @@ class tensor : public memory {
       if (old_desc_trans.is_nhwc()) {
         // giohw (acbde) => gihwo (acdeb)
         grouped_desc = grouped_desc.to_format(format_tag::acdeb);
+        grouped_desc.set_g(groups);
       } else if (old_desc_trans.is_ndhwc()) {
         // giodhw (acbdef) => gidhwo (acdefb)
         // TODO: onednn doesn't have the tag of acdefb for now
@@ -991,6 +993,7 @@ class tensor : public memory {
              /*h*/ w * o,
              /*w*/ o}};
         grouped_desc = new_desc;
+        grouped_desc.set_g(groups);
       }
     } else {
       // conv: judge whether is channels last on oihw format

--- a/include/ideep/utils.hpp
+++ b/include/ideep/utils.hpp
@@ -280,6 +280,15 @@ inline int tensor_scale_mask(dim scale_size, bool grouped) {
   return scale_size > 1 ? grouped ? 3 : 1 : 0;
 }
 
+inline int conv_weight_scale_mask(int scale_size, bool is_grouped, bool is_deconv) {
+  if (scale_size <= 1) return 0;
+  if (is_grouped) {
+    if (is_deconv) return 4;
+    else return 2;
+  }
+  return is_deconv ? 2 : 1;
+}
+
 inline int tensor_zp_mask(dim zp_size) {
   return zp_size > 1 ? 1 : 0;
 }


### PR DESCRIPTION
Migrate to oneDNN 3.0 API for IPEX and PyTorch.

**Major changes of oneDNN**
- `dnnl::memory::desc` struct become opaque. Can only access via API. Read only, cannot write.
- `primitive_attr` no longer keeps info of scales or zero points. Scales and zero points are set at runtime. Set masks of scales and zero points to `primitive_attr` to create primitive desc (pd).
- Output scales are no longer used for pd creation and computation. Set src/wei/dst, etc. scales separately.
- API to create `primitive_desc` is changed
- Parameter `scale` is removed from post-op fusion API. Some default parameters are changed (e.g., `hardswish`).
- Scale and shift are separated for batchnorm
- A few deprecated APIs are removed.

**Changes in ideep**
- `dnnl::primitive_attr` no longer holds scales and zero points.
  - Keep scales and zero points as well as their masks in `ideep::attr_t`. Define `std::unordered_map<int, scale-mask-pair>` and `std::unordered_map<int, zp-mask-pair>` in `attr_t`. Keys are DNNL args (e.g. `DNNL_ARG_SRC`)
  - Keep API of `set_scales` and `set_zero_points` of `ideep::attr_t`. They set masks to base class `dnnl::primitive_attr` and store these info in `ideep::attr_t::all_scales` and `ideep::attr_t::all_zero_points`, which are maps mentioned above.
  - Removed `forward_quant_parameters` for conv and deconv which used to keep scale and zp. Define `std::shared_ptr<std::unordered_map<int, tensor>> all_scales, all_zero_points` in `forward_params` to keep scales and zps as tensors for primitive execution. They are filled in `do_prepare`.
  - For quantization, fp32 bias does not need to be scaled before passing to primitive.
- `dnnl::memory::desc` has become opaque.
  - `ideep::tensor::desc::to_type()` returns a new desc by cloning an existing one and change its data type. Now we cannot change a desc's data type directly. Solution: (1) Use strides and data type to create a new desc if the given desc is in plain format. (2) Create a binary primitive desc to query a new desc if the given desc is in blocked format.
  - Keep group info in `ideep::tensor::desc` and `ideep::tensor`. We used to keep it in `dnnl::memory::desc`.
- API to create `primitive_desc` is changed.
  - Use new API to create `primitive_desc` for various ops.
- Post-op fusion API is changed. Parameter `scale` is removed. 
  - Remove the parameter in ideep. For some post-ops, old APIs are used with scales (`1.0f`). we need to keep the old API and name the new as `_v2`

**Test Plan**
- IPEX UT
- Some of PyTorch UT (test_quantization.py, test_mkldnn.py, test_mkldnn_fusion.py)

@jgong5 @XiaobingSuper @yanbing-j @Guobing-Chen @EikanWang Please review. Thanks!