### PR TITLE
Add a parameter to control expected deconv weight format

### DIFF
--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -415,7 +415,12 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
                with_bias, dst, src_zero_point, groups);
   }
 
-  template <bool is_channels_last = false>
+  /// @param is_channels_last Indicate whether weight is channels-last or not.
+  /// @param transposed If true, return weight desc in [i, o, ...] or [g, i/g, o, ...]
+  ///                   format, which is used by PyTorch/Aten. If false, return desc in
+  ///                   [o, i, ...] or [g, o, i/g, ...] format used by oneDNN. By default
+  ///                   it is true for backward compatibility (e.g. Caffe2)
+  template <bool is_channels_last = false, bool transposed = true>
   static tensor::desc expected_weights_desc(
       const dims& weights_dims,   // [i, o, ...]
       data_type dtype = data_type::f32,
@@ -498,11 +503,19 @@ struct convolution_transpose_forward : public dnnl::deconvolution_forward {
 
     // embed group info into weights_desc
     if (grouped) {
-      // [g, o, i/g, ...] -> [g, i/g, o, ...]
-      return tensor::desc(pd.weights_desc(), groups).transpose(1, 2);
+      if (transposed) {
+        // [g, o, i/g, ...] -> [g, i/g, o, ...]
+        return tensor::desc(pd.weights_desc(), groups).transpose(1, 2);
+      } else {
+        return tensor::desc(pd.weights_desc(), groups);
+      }
     } else {
-      // [o, i, ...] -> [i, o, ...]
-      return tensor::desc(pd.weights_desc(), groups).transpose(0, 1);
+      if (transposed) {
+        // [o, i, ...] -> [i, o, ...]
+        return tensor::desc(pd.weights_desc(), groups).transpose(0, 1);
+      } else {
+        return tensor::desc(pd.weights_desc(), groups);
+      }
     } 
   }
 


### PR DESCRIPTION
> Porting of https://github.com/intel/ideep/pull/145 (Approved by @jgong5)

**Summary**
Add a template parameter 'transposed' to control memory format for `convolution_transpose_forward::expected_weights_desc`.
The format queried from primitive desc is `[o, i, ...]` or `[g, o, i/g, ...]`. It is used by oneDNN. However, the default format for PyTorch/ATen is `[i, o, ...]` or `[g, i/g, o, ...]`.
In `convolution_transpose_forward::expected_weights_desc`, we used to transpose the queried desc from `oi` to `io` for Caffe2. And for onednn quantization backend and IPEX, we get `io` just as Caffe2. Then we transpose it again to `oi` in the framework to use oneDNN for computation.
But it is found that in oneDNN 3.0, transposing a quantized weight desc is not allowed anymore. So, here I add a parameter `transposed` to control the desc format returned by `expected_weights_desc`. When `transposed = true`, the behavior is unchanged as before. When `transposed = false`, the desc returned by `expected_weights_desc` is just `oi` so that we don't need to transpose it.
The parameter is set to `true` by default for compatibility. Later we will use `transposed = false` for onednn quantization backend and IPEX and then migrate to oneDNN 3.0.

**Test plan**
- PyTorch: test_quantization.py
- Caffe2: conv_transpose_test.py
- IPEX: test_jit.py

@jgong5 @XiaobingSuper @yanbing-j @Guobing-Chen