### PR TITLE
Enable set post op sum zero point of conv_add and conv_add_relu

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -57,10 +57,10 @@ struct attr_t : public dnnl::primitive_attr {
   }
 
   // Helper factory
-  static attr_t fuse_sum(float scale = 1.0) {
+  static attr_t fuse_sum(float scale = 1.0, int32_t sum_zero_point = 0) {
     attr_t attr;
     post_ops po;
-    po.append_sum(scale);
+    po.append_sum(scale, sum_zero_point);
     attr.set_post_ops(po);
     return attr;
   }
@@ -164,6 +164,20 @@ struct attr_t : public dnnl::primitive_attr {
     attr_t attr;
     post_ops po;
     po.append_sum(sum_scale);
+    po.append_eltwise(relu_scale, algorithm::eltwise_relu, alpha, beta);
+    attr.set_post_ops(po);
+    return attr;
+  }
+
+  static attr_t residual_with_sum_zero_point(
+      float sum_scale = 1.0,
+      int32_t sum_zero_point = 0,
+      float relu_scale = 1.0,
+      float alpha = 0.f,
+      float beta = 0.f) {
+    attr_t attr;
+    post_ops po;
+    po.append_sum(sum_scale, sum_zero_point);
     po.append_eltwise(relu_scale, algorithm::eltwise_relu, alpha, beta);
     attr.set_post_ops(po);
     return attr;

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1231,10 +1231,7 @@ struct convolution_forward
       algorithm aalgorithm = algorithm::convolution_direct,
       prop_kind aprop_kind = prop_kind::forward,
       const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine(),
-      const zero_point_t& src_zero_points = zero_point_t(),
-      const zero_point_t& weights_zero_points = zero_point_t(),
-      const zero_point_t& dst_zero_points = zero_point_t()) {
+      const engine& aengine = engine::cpu_engine()) {
     bool is_channels_last = src.get_desc().is_channels_last() || weights.get_desc().is_channels_last();
     bool is_fp32 = src_scales.empty() && weights_scales.empty() && dst_scales.empty();
     if (is_fp32) {
@@ -1252,12 +1249,12 @@ struct convolution_forward
         do_prepare</*with_bias=*/false>(
             param, src, weights, bias, dst_dims, dst, strides, dilates,
             padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-            src_zero_points, dst_zero_points, is_channels_last, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+            zero_point_t(), zero_point_t(), is_channels_last, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
       } else {
         do_prepare</*with_bias=*/true>(
             param, src, weights, bias, dst_dims, dst, strides, dilates,
             padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-            src_zero_points, dst_zero_points, is_channels_last, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+            zero_point_t(), zero_point_t(), is_channels_last, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
       }
     }
   }
@@ -1283,10 +1280,7 @@ struct convolution_forward
       algorithm aalgorithm = algorithm::convolution_direct,
       prop_kind aprop_kind = prop_kind::forward,
       const lowp_kind alowp_kind = u8s8,
-      const engine& aengine = engine::cpu_engine(),
-      const zero_point_t& src_zero_points = zero_point_t(),
-      const zero_point_t& weights_zero_points = zero_point_t(),
-      const zero_point_t& dst_zero_points = zero_point_t()) {
+      const engine& aengine = engine::cpu_engine()) {
     bool is_channels_last = src.get_desc().is_channels_last() || weights.get_desc().is_channels_last();
     bool is_fp32 = src_scales.empty() && weights_scales.empty() && dst_scales.empty();
     static tensor dummy_bias;
@@ -1298,7 +1292,7 @@ struct convolution_forward
       do_prepare</*with_bias=*/false>(
           param, src, weights, dummy_bias, dst_dims, dst, strides, dilates,
           padding_l, padding_r, groups, src_scales, weights_scales, dst_scales,
-          src_zero_points, dst_zero_points, is_channels_last, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
+          zero_point_t(), zero_point_t(), is_channels_last, attr, aalgorithm, aprop_kind, alowp_kind, aengine);
     }
   }
 


### PR DESCRIPTION
The current post op fusion with sum didn't provide the interface to set zero point for conv_add and conv_add_relu fusion. In this PR, we will enable them for int8 convolution since Stock PyTorch supports affine quantization.
Here is the draft PR in Stock PyTorch to test it with PyTorch CI: https://github.com/pytorch/pytorch/pull/90162.