### PR TITLE
Primitive caching

### DIFF
--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -34,7 +34,7 @@ struct inner_product_forward_params {
 
 struct inner_product_forward
     : public dnnl::inner_product_forward,
-      utils::computation_cache<dnnl::inner_product_forward::primitive_desc> {
+      utils::computation_cache<std::pair<dnnl::inner_product_forward::primitive_desc, dnnl::inner_product_forward>> {
   using super = dnnl::inner_product_forward;
 
   // 2-in-1 compute, with bias
@@ -240,9 +240,10 @@ struct inner_product_forward
     return pd.weights_desc();
   }
 
-  static primitive_desc get_primitive_desc(
+  static std::pair<dnnl::inner_product_forward::primitive_desc, dnnl::inner_product_forward> get_primitive_desc(
       const tensor::desc& src_desc,
       const tensor::desc& weights_desc,
+      const size_t weights_hashkey, /* this is to check in place weight updates */
       const tensor::desc& dst_desc,
       const tensor::desc& bias_desc = tensor::desc(),
       const bool with_bias = false,
@@ -257,15 +258,20 @@ struct inner_product_forward
         dst_desc,
         attr,
         with_bias,
-        omp_get_max_threads());
-    return fetch_or_create(key, [&]() {
-      if (with_bias) {
-        return primitive_desc(
+        omp_get_max_threads(),
+        weights_hashkey);
+
+    dnnl::inner_product_forward::primitive_desc pd;
+    if (with_bias) {
+      pd = primitive_desc(
             aengine, aprop_kind, src_desc, weights_desc, bias_desc, dst_desc, attr);
-      } else {
-        return primitive_desc(
+    } else {
+      pd = primitive_desc(
             aengine, aprop_kind, src_desc, weights_desc, dst_desc, attr);
-      }
+    }
+
+    return fetch_or_create(key, [&]() {
+      return std::make_pair(pd, super(pd));
     });
   };
 
@@ -366,15 +372,17 @@ private:
 
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-    param.pd = get_primitive_desc(
+    auto pd_pair = get_primitive_desc(
         src_desc,
         weights_desc,
+        weights.get_hash(),
         dst_desc,
         bias_desc,
         with_bias,
         op_attr,
         aprop_kind);
-    param.primitive = std::move(super(param.pd));
+    param.pd = std::move(pd_pair.first);
+    param.primitive = std::move(pd_pair.second);
   }
 
   // Set reorder flags to false if you are sure the memory layout aligns
@@ -576,10 +584,10 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto forward_hints = inner_product_forward::get_primitive_desc(
-        diff_src_desc, weights_desc, diff_dst_desc, tensor::desc(), false, op_attr);
+        diff_src_desc, weights_desc, weights.get_hash(), diff_dst_desc, tensor::desc(), false, op_attr);
 
     auto pd = primitive_desc(
-        aengine, diff_src_desc, weights_desc, diff_dst_desc, forward_hints, op_attr);
+        aengine, diff_src_desc, weights_desc, diff_dst_desc, forward_hints.first, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
@@ -670,13 +678,13 @@ private:
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
     auto forward_hints = inner_product_forward::get_primitive_desc(
-        src_desc, weights_desc, diff_dst_desc, diff_bias_desc, with_diff_bias, op_attr);
+        src_desc, weights_desc, diff_weights.get_hash(), diff_dst_desc, diff_bias_desc, with_diff_bias, op_attr);
 
     auto pd = with_diff_bias
         ? primitive_desc(aengine, src_desc, diff_weights_desc, diff_bias_desc,
-                         diff_dst_desc, forward_hints, op_attr)
+                         diff_dst_desc, forward_hints.first, op_attr)
         : primitive_desc(aengine, src_desc, diff_weights_desc, diff_dst_desc,
-                         forward_hints, op_attr);
+                         forward_hints.first, op_attr);
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -4,6 +4,8 @@
 #include "attributes.hpp"
 #include "utils.hpp"
 
+#define MAX_TENSOR_SIZE_FOR_HASHING 1024
+
 namespace ideep {
 
 class tensor : public memory {
@@ -690,6 +692,13 @@ class tensor : public memory {
 
   inline size_t get_size() const {
     return get_desc().get_size();
+  }
+
+  // Return hashkey for the tensor buffer
+  inline size_t get_hash() const {
+     if (is_empty()) return 0;
+     return ideep::utils::get_array_hash_float(0 /*seed*/, (float*)get_data_handle(),
+                                               std::min(MAX_TENSOR_SIZE_FOR_HASHING, (int)get_size()));
   }
 
   /// Return whether the tensor is empty

--- a/include/ideep/utils.hpp
+++ b/include/ideep/utils.hpp
@@ -360,6 +360,48 @@ inline int set_verbose(int level) {
   return ret == dnnl::status::success;
 }
 
+// Note(snadampal): The below functions taken from mkl-dnn/src/utils/utils.hpp
+// Returns a value of type T by reinterpretting the representation of the input
+// value (part of C++20).
+//
+// Provides a safe implementation of type punning.
+//
+// Constraints:
+// - U and T must have the same size
+// - U and T must be trivially copyable
+template <typename T, typename U>
+inline T bit_cast(const U &u) {
+  static_assert(sizeof(T) == sizeof(U), "Bit-casting must preserve size.");
+  // Use std::is_pod as older GNU versions do not support
+  // std::is_trivially_copyable.
+  static_assert(std::is_pod<T>::value, "T must be trivially copyable.");
+  static_assert(std::is_pod<U>::value, "U must be trivially copyable.");
+
+  T t;
+  std::memcpy(&t, &u, sizeof(U));
+  return t;
+}
+
+inline int float2int(float x)  {
+  return bit_cast<int>(x);
+}
+
+// The following code is derived from Boost C++ library
+// Copyright 2005-2014 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+template <typename T>
+inline size_t hash_combine(size_t seed, const T &v) {
+  return seed ^= std::hash<T> {}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+inline size_t get_array_hash_float(size_t seed, const float *v, int size) {
+  for (int i = 0; i < size; i++) {
+     seed = hash_combine(seed, float2int(v[i]));
+  }
+  return seed;
+}
+
 } // namespace utils
 } // namespace ideep
 #endif


### PR DESCRIPTION
This PR is adding support for conv, matmul and inner product primitive caching. The feature is built on top of the existing primitive descriptor caching feature.

I have tested the below pytorch unit tests and there were no functional regressions observed.
test_ops.py
test_mkldnn.py
test_mkldnn_fusion.py
test_mkldnn_verbose.py
test_quantization.py

pytorch/benchmarks:  resnet50 with batchsize =32 showed ~4x improvement and the BERT_pytorch showed ~20% improvement.
