### PR TITLE
PyTorch Primitive caching

### DIFF
--- a/include/ideep/lru_cache.hpp
+++ b/include/ideep/lru_cache.hpp
@@ -149,7 +149,15 @@ class lru_cache {
   size_type capacity_;
 };
 
+#ifdef __aarch64__
+/* initializing the cache with capacity 1 (as zero is crashig) to
+ * disable it by default. And enable it for inference use cases that benefit
+ * by setting LRU_CACHE_CAPACITY to appropriate size
+ */
+template <class value_t, size_t capacity = 1, class key_t = std::string>
+#else
 template <class value_t, size_t capacity = 1024, class key_t = std::string>
+#endif
 class computation_cache {
  public:
   using iterator = typename lru_cache<key_t, value_t>::iterator;

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -34,7 +34,11 @@ struct inner_product_forward_params {
 
 struct inner_product_forward
     : public dnnl::inner_product_forward,
+#ifdef __aarch64__
+      utils::computation_cache<std::pair<dnnl::inner_product_forward::primitive_desc, dnnl::inner_product_forward>> {
+#else
       utils::computation_cache<dnnl::inner_product_forward::primitive_desc> {
+#endif
   using super = dnnl::inner_product_forward;
 
   // 2-in-1 compute, with bias
@@ -240,6 +244,44 @@ struct inner_product_forward
     return pd.weights_desc();
   }
 
+#ifdef __aarch64__
+  static std::pair<dnnl::inner_product_forward::primitive_desc, dnnl::inner_product_forward> get_primitive_desc(
+      const tensor::desc& src_desc,
+      const tensor::desc& weights_desc,
+      const size_t weights_hashkey, /* this is to check in place weight updates */
+      const tensor::desc& dst_desc,
+      const tensor::desc& bias_desc = tensor::desc(),
+      const bool with_bias = false,
+      const attr_t& attr = attr_t(),
+      const prop_kind aprop_kind = prop_kind::forward,
+      const engine& aengine = engine::cpu_engine()) {
+    auto key = utils::create_key(
+        aprop_kind,
+        src_desc,
+        weights_desc,
+        bias_desc,
+        dst_desc,
+        attr,
+        with_bias,
+        omp_get_max_threads(),
+        weights_hashkey);
+
+    dnnl::inner_product_forward::primitive_desc pd;
+    if (with_bias) {
+      pd = primitive_desc(
+            {aprop_kind, src_desc, weights_desc, bias_desc, dst_desc},
+            attr,
+            aengine);
+    } else {
+      pd = primitive_desc(
+            {aprop_kind, src_desc, weights_desc, dst_desc}, attr, aengine);
+    }
+
+    return fetch_or_create(key, [&]() {
+      return std::make_pair(pd, super(pd));
+    });
+  };
+#else
   static primitive_desc get_primitive_desc(
       const tensor::desc& src_desc,
       const tensor::desc& weights_desc,
@@ -270,6 +312,7 @@ struct inner_product_forward
       }
     });
   };
+#endif
 
 private:
   template <bool with_bias, bool reorder_src = true, bool reorder_weight = true>
@@ -367,6 +410,19 @@ private:
 
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
+#ifdef __aarch64__
+    auto pd_pair = get_primitive_desc(
+        src_desc,
+        weights_desc,
+        weights.get_hash(),
+        dst_desc,
+        bias_desc,
+        with_bias,
+        op_attr,
+        aprop_kind);
+    param.pd = std::move(pd_pair.first);
+    param.primitive = std::move(pd_pair.second);
+#else
     param.pd = get_primitive_desc(
         src_desc,
         weights_desc,
@@ -376,6 +432,7 @@ private:
         op_attr,
         aprop_kind);
     param.primitive = std::move(super(param.pd));
+#endif
   }
 
   // Set reorder flags to false if you are sure the memory layout aligns
@@ -580,11 +637,19 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
     auto op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
+#ifdef __aarch64__
+    auto forward_hints = inner_product_forward::get_primitive_desc(
+        diff_src_desc, weights_desc, weights.get_hash(), diff_dst_desc, tensor::desc(), false, op_attr);
+
+    auto pd = primitive_desc(
+        {diff_src_desc, weights_desc, diff_dst_desc}, op_attr, aengine, forward_hints.first);
+#else
     auto forward_hints = inner_product_forward::get_primitive_desc(
         diff_src_desc, weights_desc, diff_dst_desc, tensor::desc(), false, op_attr);
 
     auto pd = primitive_desc(
         {diff_src_desc, weights_desc, diff_dst_desc}, op_attr, aengine, forward_hints);
+#endif
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
@@ -674,6 +739,16 @@ private:
     auto op_attr = attr;
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
+#ifdef __aarch64__
+    auto forward_hints = inner_product_forward::get_primitive_desc(
+        src_desc, weights_desc, diff_weights.get_hash(), diff_dst_desc, diff_bias_desc, with_diff_bias, op_attr);
+
+    auto pd = with_diff_bias
+        ? primitive_desc({src_desc, diff_weights_desc, diff_bias_desc,
+                          diff_dst_desc}, op_attr, aengine, forward_hints.first)
+        : primitive_desc({src_desc, diff_weights_desc, diff_dst_desc},
+                          op_attr, aengine, forward_hints.first);
+#else
     auto forward_hints = inner_product_forward::get_primitive_desc(
         src_desc, weights_desc, diff_dst_desc, diff_bias_desc, with_diff_bias, op_attr);
 
@@ -682,6 +757,7 @@ private:
                           diff_dst_desc}, op_attr, aengine, forward_hints)
         : primitive_desc({src_desc, diff_weights_desc, diff_dst_desc},
                           op_attr, aengine, forward_hints);
+#endif
 
     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
     auto expected_src = src.reorder_if_differ_in(pd.src_desc());

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -4,6 +4,9 @@
 #include "attributes.hpp"
 #include "utils.hpp"
 
+#ifdef __aarch64__
+#define MAX_TENSOR_SIZE_FOR_HASHING 1024
+#endif
 namespace ideep {
 
 class tensor : public memory {
@@ -752,6 +755,15 @@ class tensor : public memory {
   inline size_t get_size() const {
     return get_desc().get_size();
   }
+
+#ifdef __aarch64__
+  // Return hashkey for the tensor buffer
+  inline size_t get_hash() const {
+     if (is_empty()) return 0;
+     return ideep::utils::get_array_hash_float(0 /*seed*/, (float*)get_data_handle(),
+                                               std::min(MAX_TENSOR_SIZE_FOR_HASHING, (int)get_size()));
+  }
+#endif
 
   /// Return whether the tensor is empty
   inline bool is_empty() const {

--- a/include/ideep/utils.hpp
+++ b/include/ideep/utils.hpp
@@ -317,6 +317,50 @@ inline int set_verbose(int level) {
   return ret == dnnl::status::success;
 }
 
+#ifdef __aarch64__
+// Note(snadampal): The below functions taken from mkl-dnn/src/utils/utils.hpp
+// Returns a value of type T by reinterpretting the representation of the input
+// value (part of C++20).
+//
+// Provides a safe implementation of type punning.
+//
+// Constraints:
+// - U and T must have the same size
+// - U and T must be trivially copyable
+template <typename T, typename U>
+inline T bit_cast(const U &u) {
+  static_assert(sizeof(T) == sizeof(U), "Bit-casting must preserve size.");
+  // Use std::is_pod as older GNU versions do not support
+  // std::is_trivially_copyable.
+  static_assert(std::is_pod<T>::value, "T must be trivially copyable.");
+  static_assert(std::is_pod<U>::value, "U must be trivially copyable.");
+
+  T t;
+  std::memcpy(&t, &u, sizeof(U));
+  return t;
+}
+
+inline int float2int(float x)  {
+  return bit_cast<int>(x);
+}
+
+// The following code is derived from Boost C++ library
+// Copyright 2005-2014 Daniel James.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+template <typename T>
+inline size_t hash_combine(size_t seed, const T &v) {
+  return seed ^= std::hash<T> {}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+inline size_t get_array_hash_float(size_t seed, const float *v, int size) {
+  for (int i = 0; i < size; i++) {
+     seed = hash_combine(seed, float2int(v[i]));
+  }
+  return seed;
+}
+#endif
+
 } // namespace utils
 } // namespace ideep
 #endif


### PR DESCRIPTION
This PR adds support for conv, matmul and inner product primitive caching. The feature is built on top of the existing primitive descriptor caching feature.

I have tested the below pytorch unit tests and there were no functional regressions observed.
test_ops.py
test_mkldnn.py
test_mkldnn_fusion.py
test_mkldnn_verbose.py
test_quantization.py

pytorch/benchmarks: resnet50 with batchsize =32 showed ~4x improvement and the BERT_pytorch showed ~20% improvement on AWS c7g.4xl instances.