### PR TITLE
Add src dim and attr when query weight format and fix post-op:sum+others

### DIFF
--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -657,10 +657,12 @@ struct matmul_forward : public dnnl::matmul,
       const dims& weights_dims,
       data_type dtype = data_type::f32,
       data_type x_dtype = data_type::f32,
+      const dims& src_dims = dims(),
+      const attr_t& attr = attr_t(),
       const engine& aengine = engine::cpu_engine()) {
     auto ndims = weights_dims.size();
     auto x_dims = weights_dims;
-    x_dims[ndims-2] = 1;
+    x_dims[ndims-2] = src_dims.size() == ndims && src_dims.size() > 0 ? src_dims[ndims-2] : 1;
     x_dims[ndims-1] = weights_dims[ndims-2];
     dims y_dims = (ndims == 3) ? dims({x_dims[0], x_dims[1], weights_dims[2]})
                                : dims({x_dims[0], weights_dims[1]});

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -655,9 +655,9 @@ struct matmul_forward : public dnnl::matmul,
 
   static tensor::desc expected_weights_desc(
       const dims& weights_dims,
+      const dims& src_dims = dims(),
       data_type dtype = data_type::f32,
       data_type x_dtype = data_type::f32,
-      const dims& src_dims = dims(),
       const attr_t& attr = attr_t(),
       const engine& aengine = engine::cpu_engine()) {
     auto ndims = weights_dims.size();

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -815,7 +815,7 @@ struct matmul_forward : public dnnl::matmul,
       bias_desc = bias.get_desc().to_format_any();
     }
 
-    if (attr.has_op_kind(kind::sum)) {
+    if (attr.has_op_kind(kind::sum) && attr.get_post_ops().len() == 1) {
       op_attr = attr_t::fuse_sum(sum_coeff);
     }
     if (dst_coeff != 1.0f) {

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -662,7 +662,7 @@ struct matmul_forward : public dnnl::matmul,
       const engine& aengine = engine::cpu_engine()) {
     auto ndims = weights_dims.size();
     auto x_dims = weights_dims;
-    x_dims[ndims-2] = src_dims.size() == ndims && src_dims.size() > 0 ? src_dims[ndims-2] : 1;
+    x_dims[ndims-2] = src_dims.size() > 0 && src_dims.size() == ndims ? src_dims[ndims-2] : 1;
     x_dims[ndims-1] = weights_dims[ndims-2];
     dims y_dims = (ndims == 3) ? dims({x_dims[0], x_dims[1], weights_dims[2]})
                                : dims({x_dims[0], weights_dims[1]});
@@ -673,7 +673,7 @@ struct matmul_forward : public dnnl::matmul,
     tensor::desc x_desc(x_dims, x_dtype, ndims == 2 ? tag::ab : tag::abc);
     tensor::desc y_desc(y_dims, y_dtype, ndims == 2 ? tag::ab : tag::abc);
     tensor::desc weights_desc(weights_dims , dtype, tag::any);
-    auto pd = primitive_desc(aengine, x_desc, weights_desc, y_desc);
+    auto pd = primitive_desc(aengine, x_desc, weights_desc, y_desc, attr);
     return pd.weights_desc();
   }
 


### PR DESCRIPTION
This PR intends to:
(1) Add src dim and attr when we do weight prepack to query the right weight format, otherwise reorder happens a lot; Meanwhile attr is added as well for future int8 path use;

(2) do_prepare in matmul primitive + post-ops has the issue that once we call post-op sum, it will not accept a second post-op, like matmul+sum+relu;

