### PR TITLE
add is_opaque and remove wino and rnn_packed check due to oneDNN change

### DIFF
--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -155,6 +155,10 @@ class tensor : public memory {
       return is_rnn_packed_desc();
     }
 
+    inline bool is_opaque() const {
+      return is_opaque_desc();
+    }
+
     inline bool is_default() const {
       if (!is_plain())
         return false;
@@ -394,6 +398,10 @@ class tensor : public memory {
 
     bool is_rnn_packed_desc() const {
       return get_format_kind() == dnnl_format_kind_rnn_packed;
+    }
+
+    bool is_opaque_desc() const {
+      return get_format_kind() == format_kind::opaque;
     }
 
     void set_g(dim groups) {

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -151,10 +151,6 @@ class tensor : public memory {
       return is_blocking_desc() && get_inner_nblks() == 0;
     };
 
-    inline bool is_rnn_packed() const {
-      return is_rnn_packed_desc();
-    }
-
     inline bool is_opaque() const {
       return is_opaque_desc();
     }
@@ -391,15 +387,6 @@ class tensor : public memory {
       return get_format_kind() == format_kind::blocked;
     }
 
-    // Deprecated. Not used in PyTorch.
-    bool is_wino_desc() const {
-      return get_format_kind() == dnnl_format_kind_wino;
-    }
-
-    bool is_rnn_packed_desc() const {
-      return get_format_kind() == dnnl_format_kind_rnn_packed;
-    }
-
     bool is_opaque_desc() const {
       return get_format_kind() == format_kind::opaque;
     }
@@ -417,11 +404,6 @@ class tensor : public memory {
     }
 
     int groups = 1;
-    // The following two formats are now internal only in oneDNN
-    // Copy them here for compatibility
-    static const format_kind_t internal_only_start = (format_kind_t)(1 << 8);
-    static const format_kind_t dnnl_format_kind_wino = internal_only_start;
-    static const format_kind_t dnnl_format_kind_rnn_packed = (format_kind_t)((int)internal_only_start + 1);
   };
 
   desc get_desc() const {


### PR DESCRIPTION
## Description
Due to oneDNN change in https://github.com/oneapi-src/oneDNN/commit/22b9aec94dd0956f26dd411ed7aee21cf8ba7735 and  https://github.com/oneapi-src/oneDNN/commit/891aab28248d5face7cf906e3e5261cb5d74abf2 which will hide `format_kind::rnn_packed` and `format_kind::wino` by `format_kind::opaque`, need to add a check for `format_kind::opaque` and remove the deprecated check on `wino` and `rnn_packed`.

The change has been made starting from oneDNN v3.0 release.

### Additional context
For `rnn_packed` format, when the `seq_lens` of the input changes, the format of weight also changes. However, oneDNN does not support reorder from `rnn_packed` back to `public` or reorder from `rnn_packed` to a different `rnn_packed` format. In IPEX, we have a check to disable weight prepack when the queried weight format is `rnn_packed`.

Due to the format kind change in oneDNN, the check in IPEX is invalid. I will update the check in IPEX once this change in ideep has been merged.

For `blocked` format weight, weight prepack will be turned on as before.


