### PR TITLE
Do not set scales/zero points to attr if they are default values

### DIFF
--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -75,7 +75,7 @@ struct conv_deconv_utils {
                                  tensor::desc& dst_desc /* Output */) {
     scale_t dst_scales_in;
     data_type dst_data_type;
-    op_attr = attr;
+    op_attr.set_post_ops(attr.get_post_ops());
 
     // make weights and dilates compatible with DNNL
     weight_grouped = weights.make_grouped_weights(groups, is_deconv);
@@ -127,8 +127,10 @@ struct conv_deconv_utils {
         }
       }
       // Set scales to op_attr
-      int src_scale_mask = 0;
-      op_attr.set_scales(DNNL_ARG_SRC, src_scale_mask, {1.0f / src_scales_in[0]});
+      if (src_scales_in[0] != 1.0f) {
+        int src_scale_mask = 0;
+        op_attr.set_scales(DNNL_ARG_SRC, src_scale_mask, {1.0f / src_scales_in[0]});
+      }
       // For grouped conv, weight format is `goi...`, where g is groups and o and i are OC/IC per group.
       // `weight.get_dim(0)` returns g * o and `get_dim(1)` returns i.
       // For non-grouped conv (groups = 1), weight format is `oi...`.
@@ -140,18 +142,26 @@ struct conv_deconv_utils {
       auto wei_scale_mask = utils::conv_weight_scale_mask(
           weights_scales_in.size(), oc_per_group, groups, is_deconv);
       auto wei_scales = weights_scales_in;
-      for (auto& s : wei_scales) {
-        s = 1.0 / s;
+      if (!std::all_of(wei_scales.begin(), wei_scales.end(), [](float i){ return i == 1.0f; })) {
+        for (auto& s : wei_scales) {
+          s = 1.0 / s;
+        }
+        op_attr.set_scales(DNNL_ARG_WEIGHTS, wei_scale_mask, wei_scales);
       }
-      op_attr.set_scales(DNNL_ARG_WEIGHTS, wei_scale_mask, wei_scales);
-      int dst_scale_mask = 0;
-      op_attr.set_scales(DNNL_ARG_DST, dst_scale_mask, {1.0f / dst_scales_in[0]});
-
+      if (dst_scales_in[0] != 1.0f) {
+        int dst_scale_mask = 0;
+        op_attr.set_scales(DNNL_ARG_DST, dst_scale_mask, {1.0f / dst_scales_in[0]});
+      }
       // Set zero points to op_attr (weight zero point is always 0. Do not set.)
-      auto src_zp_mask = utils::tensor_zp_mask(src_zero_point_size);
-      op_attr.set_zero_points(DNNL_ARG_SRC, src_zp_mask, src_zero_point);
-      auto dst_zp_mask = utils::tensor_zp_mask(dst_zero_point_size);
-      op_attr.set_zero_points(DNNL_ARG_DST, dst_zp_mask, dst_zero_point);
+      // Only set non-zero zero points otherwise there is extra oneDNN overhead
+      if (src_zero_point[0] != 0) {
+        auto src_zp_mask = utils::tensor_zp_mask(src_zero_point_size);
+        op_attr.set_zero_points(DNNL_ARG_SRC, src_zp_mask, src_zero_point);
+      }
+      if (dst_zero_point[0] != 0) {
+        auto dst_zp_mask = utils::tensor_zp_mask(dst_zero_point_size);
+        op_attr.set_zero_points(DNNL_ARG_DST, dst_zp_mask, dst_zero_point);
+      }
 
       src_desc = {src.get_dims(),
                   alowp_kind == u8s8 ? data_type::u8 : data_type::s8, tag::any};

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -898,7 +898,7 @@ struct matmul_forward : public dnnl::matmul,
     attr_t& src_attr = param.src_attr;
     attr_t& weights_attr = param.weights_attr;
     attr_t& bias_attr = param.bias_attr;
-    op_attr = attr;
+    op_attr.set_post_ops(attr.get_post_ops());
     scale_t dst_scales_in;
     auto dst_data_type = data_type::u8;
 
@@ -964,18 +964,26 @@ struct matmul_forward : public dnnl::matmul,
       op_attr = attr_t::fuse_sum(sum_scale);
     }
 
-    op_attr.set_scales(DNNL_ARG_SRC, utils::op_scale_mask(src_scales_in.size()), src_scales_in);
-    auto wei_scales = weights_scales_in;
-    for (auto& s : wei_scales) {
-      s = 1.0 / s;
+    if (src_scales_in[0] != 1.0f) {
+      op_attr.set_scales(DNNL_ARG_SRC, utils::op_scale_mask(src_scales_in.size()), src_scales_in);
     }
-    op_attr.set_scales(DNNL_ARG_WEIGHTS, utils::op_scale_mask(wei_scales.size()), wei_scales);
+    auto wei_scales = weights_scales_in;
+    if (!std::all_of(wei_scales.begin(), wei_scales.end(), [](float i){ return i == 1.0f; })) {
+      for (auto& s : wei_scales) {
+        s = 1.0 / s;
+      }
+      op_attr.set_scales(DNNL_ARG_WEIGHTS, utils::op_scale_mask(wei_scales.size()), wei_scales);
+    }
     for (auto& s : dst_scales_in) {
       s = dst_coeff / s;
     }
-    op_attr.set_scales(DNNL_ARG_DST, utils::op_scale_mask(dst_scales_in.size()), dst_scales_in);
-    op_attr.set_zero_points(DNNL_ARG_SRC,
-                            utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
+    if (dst_scales_in[0] != 1.0f) {
+      op_attr.set_scales(DNNL_ARG_DST, utils::op_scale_mask(dst_scales_in.size()), dst_scales_in);
+    }
+    if (src_zero_point[0] != 0) {
+      op_attr.set_zero_points(DNNL_ARG_SRC,
+                              utils::tensor_zp_mask(src_zero_point.size()), src_zero_point);
+    }
     if (src.get_data_type() == data_type::f32) {
       // Set zero point for src reorder (fp32 -> int8).
       // First arg should be DNNL_ARG_DST rather than DNNL_ARG_SRC
@@ -983,7 +991,7 @@ struct matmul_forward : public dnnl::matmul,
                                utils::tensor_zp_mask(src_zero_point.size()),
                                src_zero_point);
     }
-    if (dst_data_type != data_type::f32) {
+    if (dst_data_type != data_type::f32 && dst_zero_point[0] != 0) {
       op_attr.set_zero_points(DNNL_ARG_DST,
                               utils::tensor_zp_mask(dst_zero_point.size()), dst_zero_point);
     }


### PR DESCRIPTION
**Summary**
It is fonud that ignore default scales (1.0) and zero points (0) will reduce oneDNN kernel overhead. oneDNN used to check them themselves in V2.7. Since V3.x requires scales & zero points to be set at runtime, they cannot check when creating primitive. So, framework needs to check default values of scales/zero points.
This PR adds the checks for quantized conv/deconv/matmul.
Intend to merge to ideep_dev branch as PyTorch with oneDNN 3.2 will use a branch derived from ideep_dev branch.

**Test plan**
Covered by PyTorch UT. IPEX won't use this.

@jgong5 @XiaobingSuper Please review. Thanks.
