### PR TITLE
Add version number for ideep

### DIFF
--- a/include/ideep.hpp
+++ b/include/ideep.hpp
@@ -40,4 +40,14 @@
 #include "ideep/tensor.hpp"
 #include "ideep/computations.hpp"
 
+// The ideep version number has four segments
+// The first three are the same as oneDNN version numbers
+// The fourth is to indicate ideep API change
+// So, ideep version = MAJOR.MINOR.PATCH.REVISION
+// e.g., 3.1.0.0
+#define IDEEP_VERSION_MAJOR    DNNL_VERSION_MAJOR
+#define IDEEP_VERSION_MINOR    DNNL_VERSION_MINOR
+#define IDEEP_VERSION_PATCH    DNNL_VERSION_PATCH
+#define IDEEP_VERSION_REVISION 0
+
 #endif


### PR DESCRIPTION
Add version number to ideep.
The version number consists of 4 segments: `MAJOR.MINOR.PATCH.REVISION`.
The first three segments are the same as oneDNN version numbers. The fourth is to indicate ideep API change. E.g., 3.1.0.0.

Add this to `ideep_dev` branch because we will use this branch as a base for the branch for PyTorch.

@XiaobingSuper @jgong5 @yanbing-j @guobing-chen Please review. Thanks!