### PR TITLE
Fix onednn 3 1 upgrade scale of qconv sum

### DIFF
--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -132,8 +132,9 @@ struct conv_deconv_utils {
         // Here we need to recalculate the scale of sum.
         // When fused with sum, dst_scales_in is the final output tensor's scale.
         // dst.scale is the scale of sum tensor.
-        float sum_scale =
-            dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+
+        float sum_scale = 1.0 / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+
         // When fused with sum, the dst tensor is same as the sum tensor.
         // So the sum_zero_point will be fetched from the dst tensor.
         int32_t sum_zero_point = dst.has_zero_point() ? dst.get_zero_point()[0] : 0;

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -989,7 +989,7 @@ struct matmul_forward : public dnnl::matmul,
 
     if (attr.has_op_kind(kind::sum)) {
       float sum_scale =
-          sum_coeff * dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+          sum_coeff / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
       op_attr = attr_t::fuse_sum(sum_scale);
     }
 


### PR DESCRIPTION
Refer to the RFC: https://github.com/oneapi-src/oneDNN/tree/rfcs/rfcs/20220201-quantization-scaling

- Previously, the post op calculation are after `output_scale` calculation, so the sum scale need to count for the `output_scale`. 
- Now the post op calculation are in float32 before requant to int8.

Fix this issue in ideep with oneDNN 3.1 upgrade, otherwise it causes accuracy issue for models use conv_add fusion like RN50 after upgrade PyTorch to oneDNN 3.1.