### PR TITLE
Support QConv add/add_relu in IPEX IDeep

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -330,18 +330,20 @@ struct attr_t : public dnnl::primitive_attr {
     return po.len() > 0;
   }
 
-  std::tuple<kind, float, float, float, algorithm> get_params(int index) const {
+  std::tuple<kind, float, float, float, algorithm, int32_t> get_params(int index) const {
     auto po = get_post_ops();
     IDEEP_ENFORCE(index < po.len(), "post_ops index is out of range");
 
     algorithm alg = algorithm::undef;
     float scale = 1.0, alpha = 1.0, beta = 0.0;
     memory::desc binary_src_desc;
+    int32_t zero_point = 0;
+    memory::data_type post_op_sum_dtype;
 
     auto akind = po.kind(index);
     switch (akind) {
       case kind::sum:
-        po.get_params_sum(index, scale);
+        po.get_params_sum(index, scale, zero_point, post_op_sum_dtype);
         break;
       case kind::eltwise:
         po.get_params_eltwise(index, alg, alpha, beta);
@@ -354,7 +356,7 @@ struct attr_t : public dnnl::primitive_attr {
         break;
     }
 
-    return std::make_tuple(akind, scale, alpha, beta, alg);
+    return std::make_tuple(akind, scale, alpha, beta, alg, zero_point);
   }
 
   bool non_negitive_output() const {
@@ -411,11 +413,12 @@ struct attr_t : public dnnl::primitive_attr {
       algorithm l_alg, r_alg;
       float l_scale = 1.0, l_alpha = 1.0, l_beta = 0.0;
       float r_scale = 1.0, r_alpha = 1.0, r_beta = 0.0;
-      std::tie(l_akind, l_scale, l_alpha, l_beta, l_alg) = get_params(index);
-      std::tie(r_akind, r_scale, r_alpha, r_beta, r_alg) =
+      int32_t l_zp = 0, r_zp = 0;
+      std::tie(l_akind, l_scale, l_alpha, l_beta, l_alg, l_zp) = get_params(index);
+      std::tie(r_akind, r_scale, r_alpha, r_beta, r_alg, r_zp) =
           rhs.get_params(index);
       if (l_akind != r_akind || l_alg != r_alg || l_scale != r_scale ||
-          l_alpha != r_alpha || l_beta != r_beta) {
+          l_alpha != r_alpha || l_beta != r_beta || l_zp != r_zp) {
         return false;
       }
     }
@@ -429,13 +432,16 @@ struct attr_t : public dnnl::primitive_attr {
       kind akind;
       algorithm alg = algorithm::undef;
       float scale = 1.0, alpha = 1.0, beta = 0.0;
-      std::tie(akind, scale, alpha, beta, alg) = get_params(i);
+      int32_t zp = 0;
+      std::tie(akind, scale, alpha, beta, alg, zp) = get_params(i);
 
       switch (akind) {
         case kind::sum:
           utils::to_bytes(bytes, akind);
           bytes.append(1, '.');
           utils::to_bytes(bytes, scale);
+          bytes.append(1, '.');
+          utils::to_bytes(bytes, zp);
           break;
         case kind::eltwise:
           utils::to_bytes(bytes, akind);

--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -124,10 +124,10 @@ struct attr_t : public dnnl::primitive_attr {
     return attr;
   }
 
-  static attr_t fuse_sum(float scale = 1.0) {
+  static attr_t fuse_sum(float scale = 1.0, int32_t sum_zero_point = 0) {
     attr_t attr;
     post_ops po;
-    po.append_sum(scale);
+    po.append_sum(scale, sum_zero_point);
     attr.set_post_ops(po);
     return attr;
   }
@@ -219,6 +219,19 @@ struct attr_t : public dnnl::primitive_attr {
     attr_t attr;
     post_ops po;
     po.append_sum(sum_scale);
+    po.append_eltwise(algorithm::eltwise_relu, alpha, beta);
+    attr.set_post_ops(po);
+    return attr;
+  }
+
+  static attr_t residual_with_sum_zero_point(
+      float sum_scale = 1.0,
+      int32_t sum_zero_point = 0,
+      float alpha = 0.f,
+      float beta = 0.f) {
+    attr_t attr;
+    post_ops po;
+    po.append_sum(sum_scale, sum_zero_point);
     po.append_eltwise(algorithm::eltwise_relu, alpha, beta);
     attr.set_post_ops(po);
     return attr;

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1415,6 +1415,7 @@ struct convolution_forward
         weights_desc_query,
         with_bias,
         bias_desc_query,
+        dst_desc_query,
         strides,
         dilates,
         padding_l,

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -110,20 +110,36 @@ struct conv_deconv_utils {
       const auto& src_zero_point = src.has_zero_point() ? src.get_zero_point() :
                                    src_zero_points.empty() ? default_zero_point : src_zero_points;
       const auto& weights_zero_point = weight_grouped.has_zero_point() ? weight_grouped.get_zero_point() : default_zero_point;
-      const auto& dst_zero_point = dst.has_zero_point() ? dst.get_zero_point() :
-                                   dst_zero_points.empty() ? default_zero_point : dst_zero_points;
+      const auto& dst_zero_point = [&]() {
+        if (attr.has_op_kind(kind::sum)) {
+          // Similar logic as dst_scales_in. Since when fused with sum, the dst will be the tensor of sum,
+          // In this case, the output tensor' dst_zero_points and dst_scales_in should be passed in explicitly.
+          IDEEP_ENFORCE(!dst_zero_points.empty(), "When conv fused with sum, dst_zero_points must be passed in.");
+          return dst_zero_points;
+        } else {
+          // Keep the original logic for finding dst_zero_point when not fused with sum.
+          return dst.has_zero_point() ? dst.get_zero_point() :
+                dst_zero_points.empty() ? default_zero_point : dst_zero_points;
+        }
+      }();
       const auto src_zero_point_size = static_cast<dim>(src_zero_point.size());
       const auto dst_zero_point_size = static_cast<dim>(dst_zero_point.size());
       IDEEP_ENFORCE(src_zero_point_size == 1 && dst_zero_point_size == 1,
                     "DNNL only support 1-dim zero_point");
 
       if (attr.has_op_kind(kind::sum)) {
+        // Here we need to recalculate the scale of sum.
+        // When fused with sum, dst_scales_in is the final output tensor's scale.
+        // dst.scale is the scale of sum tensor.
         float sum_scale =
             dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+        // When fused with sum, the dst tensor is same as the sum tensor.
+        // So the sum_zero_point will be fetched from the dst tensor.
+        int32_t sum_zero_point = dst.has_zero_point() ? dst.get_zero_point()[0] : 0;
         if (attr.has_op_kind(kind::eltwise)) {
-          op_attr = attr_t::residual(sum_scale);
+          op_attr = attr_t::residual_with_sum_zero_point(sum_scale, sum_zero_point);
         } else {
-          op_attr = attr_t::fuse_sum(sum_scale);
+          op_attr = attr_t::fuse_sum(sum_scale, sum_zero_point);
         }
       }
       // Set scales to op_attr

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -131,8 +131,7 @@ struct conv_deconv_utils {
         // Here we need to recalculate the scale of sum.
         // When fused with sum, dst_scales_in is the final output tensor's scale.
         // dst.scale is the scale of sum tensor.
-        float sum_scale =
-            dst_scales_in[0] / (dst.has_scale() ? dst.get_scale()[0] : 1.0f);
+        float sum_scale = 1.0/(dst.has_scale() ? dst.get_scale()[0] : 1.0f);
         // When fused with sum, the dst tensor is same as the sum tensor.
         // So the sum_zero_point will be fetched from the dst tensor.
         int32_t sum_zero_point = dst.has_zero_point() ? dst.get_zero_point()[0] : 0;


### PR DESCRIPTION
Porting the IDeep diff in PyTorch IDeep back to IPEX IDeep to support qconv add/add_relu fusion.