### PR TITLE
Add bf16/f16 backward check on SRF

### DIFF
--- a/include/ideep/abstract_types.hpp
+++ b/include/ideep/abstract_types.hpp
@@ -41,15 +41,11 @@ using rnn_direction = dnnl::rnn_direction;
 // for computation cache
 using key_t = std::string;
 
-#ifndef NDEBUG
 #define IDEEP_ENFORCE(condition, message)                                \
   do {                                                                   \
     error::wrap_c_api(                                                   \
         (condition) ? dnnl_success : dnnl_invalid_arguments, (message)); \
   } while (false)
-#else
-#define IDEEP_ENFORCE(condition, message)
-#endif
 
 const scale_t IDEEP_DEF_SCALE{1.0f};
 const zero_point_t IDEEP_DEF_ZP{0};
@@ -78,6 +74,12 @@ static bool has_fp16_type_support() {
   static bool support_fp16 =
       dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx512_core_fp16;
   return support_fp16;
+}
+
+static bool check_isa_avx2_vnni_2() {
+  static bool is_avx2_vnni_2 =
+      dnnl::get_effective_cpu_isa() == dnnl::cpu_isa::avx2_vnni_2;
+  return is_avx2_vnni_2;
 }
 
 /// cpu execution engine only.

--- a/include/ideep/operators/batchnorm.hpp
+++ b/include/ideep/operators/batchnorm.hpp
@@ -192,6 +192,10 @@ struct batch_normalization_backward
           batch_normalization_flag::use_scale |
           batch_normalization_flag::use_shift,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(src.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // TODO: support no-affine model
     auto pd_flags = flags | batch_normalization_flag::use_scale
                           | batch_normalization_flag::use_shift;

--- a/include/ideep/operators/channel_shuffle.hpp
+++ b/include/ideep/operators/channel_shuffle.hpp
@@ -46,6 +46,10 @@ struct channel_shuffle_backward : public dnnl::shuffle_backward {
       const int group,
       const int axis = 1,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto group_size = static_cast<int>(diff_dst.get_dim(axis) / group);
     auto data_desc = diff_dst.get_desc();
 

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -1869,6 +1869,10 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
                          bool is_channels_last = false,
                          algorithm aalgorithm = algorithm::convolution_direct,
                         const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -1930,6 +1934,10 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::convolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -2012,6 +2020,10 @@ struct convolution_backward_weights
                          const data_type diff_weight_type = data_type::undef,
                          algorithm aalgorithm = algorithm::convolution_direct,
                         const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     compute_impl</*with_diff_bias=*/true>(
         src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
         strides, dilates, padding_l, padding_r, groups, is_channels_last,
@@ -2032,6 +2044,10 @@ struct convolution_backward_weights
                          const data_type diff_weight_type = data_type::undef,
                          algorithm aalgorithm = algorithm::convolution_direct,
                          const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
         src, diff_dst, diff_weights_dims, diff_weights, dummy_diff_bias,
@@ -2054,6 +2070,10 @@ struct convolution_backward_weights
                       const data_type diff_weight_type = data_type::undef,
                       algorithm aalgorithm = algorithm::convolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     bool is_nhwc = diff_dst.get_desc().is_nhwc();
     bool is_ndhwc = diff_dst.get_desc().is_ndhwc();
     bool is_channels_last = is_nhwc || is_ndhwc;
@@ -2077,6 +2097,10 @@ struct convolution_backward_weights
                       const data_type diff_weight_type = data_type::undef,
                       algorithm aalgorithm = algorithm::convolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     static tensor dummy_diff_bias;
     bool is_nhwc = diff_dst.get_desc().is_nhwc();
     bool is_ndhwc = diff_dst.get_desc().is_ndhwc();
@@ -2104,10 +2128,13 @@ struct convolution_backward_weights
                            const data_type diff_weight_type,
                            algorithm aalgorithm,
                            const engine& aengine) {
-
+    data_type diff_dst_type = diff_dst.get_data_type();
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst_type,
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
-    data_type diff_dst_type = diff_dst.get_data_type();
     data_type diff_weight_type_in = data_type::undef == diff_weight_type ?
                                     diff_dst_type : diff_weight_type;
     auto diff_weights_desc =

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -759,6 +759,10 @@ struct convolution_transpose_backward_data
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::deconvolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups, true);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -814,6 +818,10 @@ struct convolution_transpose_backward_weights
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::deconvolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+   IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
    compute_impl</*with_diff_bias=*/true>(
        src, diff_dst, diff_weights_dims, diff_weights, diff_bias,
        strides, dilates, padding_l, padding_r, groups, attr, aalgorithm, aengine);
@@ -831,6 +839,10 @@ struct convolution_transpose_backward_weights
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::deconvolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
         src, diff_dst, diff_weights_dims, diff_weights, dummy_diff_bias,
@@ -851,7 +863,10 @@ private:
                            const attr_t& attr,
                            algorithm aalgorithm,
                            const engine& aengine) {
-
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
 

--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -60,6 +60,10 @@ struct eltwise_backward : public dnnl::eltwise_backward {
       float alpha = 0.0,
       float beta = 0.0,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(src.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_desc = src.get_desc();
 
     auto forward_hints = eltwise_forward::primitive_desc(

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -577,6 +577,10 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
                       tensor& diff_src,
                       const attr_t& attr = attr_t(),
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto weights_ = weights;
 
     // workaround: diff_src and weights from caffe2 may have different dims.
@@ -643,6 +647,10 @@ struct inner_product_backward_weights
                       const data_type diff_weight_type = data_type::undef,
                       const attr_t& attr = attr_t(),
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     compute_impl</*with_diff_bias=*/true>(
         src, diff_dst, diff_weights, diff_bias, diff_weight_type, attr);
   }
@@ -653,6 +661,10 @@ struct inner_product_backward_weights
                       const data_type diff_weight_type = data_type::undef,
                       const attr_t& attr = attr_t(),
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     static tensor dummy_diff_bias;
     compute_impl</*with_diff_bias=*/false>(
         src, diff_dst, diff_weights, dummy_diff_bias, diff_weight_type, attr);
@@ -667,6 +679,10 @@ private:
                            const data_type diff_weight_type,
                            const attr_t& attr = attr_t(),
                            const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_desc = src.get_desc().to_format_any();
     auto diff_dst_desc = diff_dst.get_desc().to_format_any();
     auto diff_weights_dims = src.get_dims();

--- a/include/ideep/operators/lrn.hpp
+++ b/include/ideep/operators/lrn.hpp
@@ -60,6 +60,10 @@ struct lrn_backward : public dnnl::lrn_backward {
       float k = 1.0,
       algorithm aalgorithm = algorithm::lrn_across_channels,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
     // auto src_desc = src.get_desc();

--- a/include/ideep/operators/pool.hpp
+++ b/include/ideep/operators/pool.hpp
@@ -145,6 +145,10 @@ struct pooling_backward : public dnnl::pooling_backward {
       const dims& padding_r,
       algorithm aalgorithm,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(src.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_desc = src.get_desc();
     auto dst_desc = dst.get_desc();
 
@@ -204,6 +208,10 @@ struct pooling_v2_backward : public dnnl::pooling_backward {
       const dims& padding_r,
       algorithm aalgorithm,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(src.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_desc = src.get_desc();
     auto dst_desc = dst.get_desc();
     auto dil_compatible = utils::get_compatible_dilates(dilation);

--- a/include/ideep/operators/prelu.hpp
+++ b/include/ideep/operators/prelu.hpp
@@ -56,6 +56,10 @@ struct prelu_backward : public dnnl::prelu_backward {
       tensor& diff_weight,
       prop_kind aprop_kind = prop_kind::backward,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_in = src;
     auto weight_in = weight;
     auto diff_dst_in = diff_dst;

--- a/include/ideep/operators/softmax.hpp
+++ b/include/ideep/operators/softmax.hpp
@@ -39,6 +39,10 @@ struct softmax_backward : public dnnl::softmax_backward {
       tensor& diff_src,
       int softmax_axis,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_ENFORCE(!(check_isa_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto forward_hints = softmax_forward::primitive_desc(
         aengine, prop_kind::forward_inference, algorithm::softmax_accurate,
         dst.get_desc(), dst.get_desc(), softmax_axis);


### PR DESCRIPTION
Add bf16/f16 backward check on SRF since oneDNN does not support backward of bf16/f16 on SRF.