### PR TITLE
Add avx2_vnni_2 check for bf16 and fp16 support on SRF

### DIFF
--- a/include/ideep/abstract_types.hpp
+++ b/include/ideep/abstract_types.hpp
@@ -70,13 +70,14 @@ static bool has_bf16_type_support() {
   // static bool support_bf16 = isa >= dnnl::cpu_isa::avx512_core
   //                           && isa != dnnl::cpu_isa::avx2_vnni;
   static bool support_bf16 =
-      dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx512_core;
+      dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx2_vnni_2;
   return support_bf16;
 }
 
 static bool has_fp16_type_support() {
   static bool support_fp16 =
-      dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx512_core_fp16;
+      dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx512_core_fp16 ||
+      dnnl::get_effective_cpu_isa() == dnnl::cpu_isa::avx2_vnni_2;
   return support_fp16;
 }
 

--- a/include/ideep/abstract_types.hpp
+++ b/include/ideep/abstract_types.hpp
@@ -51,6 +51,19 @@ using key_t = std::string;
 #define IDEEP_ENFORCE(condition, message)
 #endif
 
+#if defined(__GNUC__) || defined(__ICL) || defined(__clang__)
+#define IDEEP_LIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 1))
+#define IDEEP_UNLIKELY(expr) (__builtin_expect(static_cast<bool>(expr), 0))
+#else
+#define IDEEP_LIKELY(expr) (expr)
+#define IDEEP_UNLIKELY(expr) (expr)
+#endif
+
+#define IDEEP_CHECK(condition, message)                                  \
+  if (IDEEP_UNLIKELY(!(condition))) {                                    \
+    error::wrap_c_api(dnnl_invalid_arguments, (message));                \
+  }
+
 const scale_t IDEEP_DEF_SCALE{1.0f};
 const zero_point_t IDEEP_DEF_ZP{0};
 const scale_t IDEEP_EMPTY_SCALE;
@@ -72,6 +85,12 @@ static bool has_bf16_type_support() {
   static bool support_bf16 =
       dnnl::get_effective_cpu_isa() >= dnnl::cpu_isa::avx2_vnni_2;
   return support_bf16;
+}
+
+static bool check_isa_is_avx2_vnni_2() {
+  static bool is_avx2_vnni_2 =
+      dnnl::get_effective_cpu_isa() == dnnl::cpu_isa::avx2_vnni_2;
+  return is_avx2_vnni_2;
 }
 
 static bool has_fp16_type_support() {

--- a/include/ideep/operators/batchnorm.hpp
+++ b/include/ideep/operators/batchnorm.hpp
@@ -192,6 +192,10 @@ struct batch_normalization_backward
           batch_normalization_flag::use_scale |
           batch_normalization_flag::use_shift,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(src.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // TODO: support no-affine model
     auto pd_flags = flags | batch_normalization_flag::use_scale
                           | batch_normalization_flag::use_shift;

--- a/include/ideep/operators/channel_shuffle.hpp
+++ b/include/ideep/operators/channel_shuffle.hpp
@@ -46,6 +46,10 @@ struct channel_shuffle_backward : public dnnl::shuffle_backward {
       const int group,
       const int axis = 1,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto group_size = static_cast<int>(diff_dst.get_dim(axis) / group);
     auto data_desc = diff_dst.get_desc();
 

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -2008,6 +2008,10 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
                          bool is_channels_last = false,
                          algorithm aalgorithm = algorithm::convolution_direct,
                         const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2i_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -2082,6 +2086,10 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::convolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -2267,10 +2275,13 @@ struct convolution_backward_weights
                            const data_type diff_weight_type,
                            algorithm aalgorithm,
                            const engine& aengine) {
-
+    data_type diff_dst_type = diff_dst.get_data_type();
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst_type,
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
-    data_type diff_dst_type = diff_dst.get_data_type();
     data_type diff_weight_type_in = data_type::undef == diff_weight_type ?
                                     diff_dst_type : diff_weight_type;
     auto diff_weights_desc =

--- a/include/ideep/operators/deconv.hpp
+++ b/include/ideep/operators/deconv.hpp
@@ -1070,6 +1070,10 @@ struct convolution_transpose_backward_data
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::deconvolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups, true);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -1120,6 +1124,10 @@ struct convolution_transpose_backward_data
                       const attr_t& attr = attr_t(),
                       algorithm aalgorithm = algorithm::deconvolution_direct,
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make weights and dilates compatible with DNNL
     auto weights_ = weights.make_grouped_weights(groups, true);
     auto dilates_ = utils::get_compatible_dilates(dilates);
@@ -1274,7 +1282,10 @@ private:
                            const attr_t& attr,
                            algorithm aalgorithm,
                            const engine& aengine) {
-
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // make diff_weights and dilates compatible with DNNL
     auto dilates_ = utils::get_compatible_dilates(dilates);
 

--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -60,6 +60,10 @@ struct eltwise_backward : public dnnl::eltwise_backward {
       float alpha = 0.0,
       float beta = 0.0,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(src.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_desc = src.get_desc();
 
     auto forward_hints = eltwise_forward::primitive_desc(

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -632,6 +632,10 @@ struct inner_product_backward_data : public dnnl::inner_product_backward_data {
                       tensor& diff_src,
                       const attr_t& attr = attr_t(),
                       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto weights_ = weights;
 
     // workaround: diff_src and weights from caffe2 may have different dims.
@@ -730,6 +734,10 @@ private:
                            const data_type diff_weight_type,
                            const attr_t& attr = attr_t(),
                            const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_desc = src.get_desc().to_format_any();
     auto diff_dst_desc = diff_dst.get_desc().to_format_any();
     auto diff_weights_dims = src.get_dims();

--- a/include/ideep/operators/lrn.hpp
+++ b/include/ideep/operators/lrn.hpp
@@ -60,6 +60,10 @@ struct lrn_backward : public dnnl::lrn_backward {
       float k = 1.0,
       algorithm aalgorithm = algorithm::lrn_across_channels,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     // workaround: use src.get_desc() once issue intel/mkl-dnn#588 is resolved
     auto src_desc = src._get_unblocked_desc_if_4c_blocked();
     // auto src_desc = src.get_desc();

--- a/include/ideep/operators/lstm.hpp
+++ b/include/ideep/operators/lstm.hpp
@@ -312,6 +312,10 @@ struct lstm_backward : public dnnl::lstm_backward {
       const bool reverse = false,
       const attr_t& attr = attr_t(),
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(src_layer.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto aprop = prop_kind::backward;
     auto direction = reverse ? rnn_direction::unidirectional_right2left
                              : rnn_direction::unidirectional_left2right;

--- a/include/ideep/operators/pool.hpp
+++ b/include/ideep/operators/pool.hpp
@@ -145,6 +145,10 @@ struct pooling_backward : public dnnl::pooling_backward {
       const dims& padding_r,
       algorithm aalgorithm,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(src.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_desc = src.get_desc();
     auto dst_desc = dst.get_desc();
 
@@ -204,6 +208,10 @@ struct pooling_v2_backward : public dnnl::pooling_backward {
       const dims& padding_r,
       algorithm aalgorithm,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(src.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_desc = src.get_desc();
     auto dst_desc = dst.get_desc();
     auto dil_compatible = utils::get_compatible_dilates(dilation);

--- a/include/ideep/operators/prelu.hpp
+++ b/include/ideep/operators/prelu.hpp
@@ -56,6 +56,10 @@ struct prelu_backward : public dnnl::prelu_backward {
       tensor& diff_weight,
       prop_kind aprop_kind = prop_kind::backward,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto src_in = src;
     auto weight_in = weight;
     auto diff_dst_in = diff_dst;

--- a/include/ideep/operators/softmax.hpp
+++ b/include/ideep/operators/softmax.hpp
@@ -39,6 +39,10 @@ struct softmax_backward : public dnnl::softmax_backward {
       tensor& diff_src,
       int softmax_axis,
       const engine& aengine = engine::cpu_engine()) {
+    IDEEP_CHECK(!(check_isa_is_avx2_vnni_2() &&
+                  utils::one_of(diff_dst.get_data_type(),
+                                data_type::bf16, data_type::f16)),
+                  "DNNL does not support bf16/f16 backward on the platform with avx2_vnni_2");
     auto forward_hints = softmax_forward::primitive_desc(
         aengine, prop_kind::forward_inference, algorithm::softmax_accurate,
         dst.get_desc(), dst.get_desc(), softmax_axis);


### PR DESCRIPTION
* add avx2_vnni_2 check for bf16 and fp16 support on SRF
* add bf16/f16 backward check to explicitly throw message that bf16/f16 backward is not supported on SRF. Add a new check `IDEEP_CHECK` instead of enabling `IDEEP_ENFORCE` in release mode. It is because enabling `IDEEP_ENFORCE` will reduce the performance of RN50 real-time inference by ~4%.