### PR TITLE
[aarch64] update the Primtive cache logic for ACL fixed format kernels

### DIFF
--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -855,30 +855,7 @@ struct matmul_forward : public dnnl::matmul,
     if (!dst.is_empty()) {
       dst_desc = dst.get_desc().to_type(dst_data_type);
     }
-#ifdef __aarch64__
-    auto key = utils::create_key(
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        op_attr,
-        with_bias,
-        omp_get_max_threads(),
-        weights.get_hash());
 
-    if (with_bias) {
-      param.pd = primitive_desc(
-            aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
-    } else {
-      param.pd = primitive_desc(
-            aengine, src_desc, weights_desc, dst_desc, op_attr);
-    }
-
-    auto pd_pair = fetch_or_create(key, [&]() {
-      return std::make_pair(param.pd, super(param.pd));
-    });
-    param.primitive = std::move(pd_pair.second);
-#else
     auto key = utils::create_key(
         src_desc,
         weights_desc,
@@ -887,6 +864,21 @@ struct matmul_forward : public dnnl::matmul,
         op_attr,
         with_bias,
         omp_get_max_threads());
+
+#ifdef __aarch64__
+    auto pd_pair = fetch_or_create(key, [&]() {
+      if (with_bias) {
+        param.pd = primitive_desc(
+            aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
+      } else {
+        param.pd = primitive_desc(
+            aengine, src_desc, weights_desc, dst_desc, op_attr);
+      }
+      return std::make_pair(param.pd, super(param.pd));
+    });
+    param.pd = std::move(pd_pair.first);
+    param.primitive = std::move(pd_pair.second);
+#else
     param.pd = fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(
@@ -1047,30 +1039,6 @@ struct matmul_forward : public dnnl::matmul,
     if (!dst.is_empty()) {
       dst_desc = dst.get_desc().to_type(dst_data_type);
     }
-#ifdef __aarch64__
-    auto key = utils::create_key(
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        op_attr,
-        with_bias,
-        omp_get_max_threads(),
-        weights.get_hash());
-
-    if (with_bias) {
-      param.pd =  primitive_desc(
-            aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
-    } else {
-      param.pd =  primitive_desc(
-            aengine, src_desc, weights_desc, dst_desc, op_attr);
-    }
-
-    auto pd_pair = fetch_or_create(key, [&]() {
-      return std::make_pair(param.pd, super(param.pd));
-    });
-    param.primitive = std::move(pd_pair.second);
-#else
     auto key = utils::create_key(
         src_desc,
         weights_desc,
@@ -1079,6 +1047,20 @@ struct matmul_forward : public dnnl::matmul,
         op_attr,
         with_bias,
         omp_get_max_threads());
+#ifdef __aarch64__
+    auto pd_pair = fetch_or_create(key, [&]() {
+      if (with_bias) {
+        param.pd =  primitive_desc(
+            aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
+      } else {
+        param.pd =  primitive_desc(
+            aengine, src_desc, weights_desc, dst_desc, op_attr);
+      }
+      return std::make_pair(param.pd, super(param.pd));
+    });
+    param.pd = std::move(pd_pair.first);
+    param.primitive = std::move(pd_pair.second);
+#else
     param.pd = fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(
@@ -1211,32 +1193,6 @@ struct matmul_forward : public dnnl::matmul,
       bias_desc = {bias.get_dims(), data_type::f32, bia_tag};
     }
 
-
-    // Create pd and primitive
-#ifdef __aarch64__
-    auto key = utils::create_key(
-        src_desc,
-        weights.get_desc(),
-        bias_desc,
-        dst_desc,
-        op_attr,
-        with_bias,
-        omp_get_max_threads(),
-        weights.get_hash());
-
-    if (with_bias) {
-      param.pd = primitive_desc(
-          aengine, src_desc, weights.get_desc(), bias_desc, dst_desc, op_attr);
-    } else {
-      param.pd = primitive_desc(
-          aengine, src_desc, weights.get_desc(), dst_desc, op_attr);
-    }
-
-    auto pd_pair = fetch_or_create(key, [&]() {
-      return std::make_pair(param.pd, super(param.pd));
-    });
-    param.primitive = std::move(pd_pair.second);
-#else
     auto key = utils::create_key(
         src_desc,
         weights.get_desc(),
@@ -1245,6 +1201,22 @@ struct matmul_forward : public dnnl::matmul,
         op_attr,
         with_bias,
         omp_get_max_threads());
+
+    // Create pd and primitive
+#ifdef __aarch64__
+    auto pd_pair = fetch_or_create(key, [&]() {
+      if (with_bias) {
+        param.pd = primitive_desc(
+            aengine, src_desc, weights.get_desc(), bias_desc, dst_desc, op_attr);
+      } else {
+        param.pd = primitive_desc(
+            aengine, src_desc, weights.get_desc(), dst_desc, op_attr);
+      }
+      return std::make_pair(param.pd, super(param.pd));
+    });
+    param.pd = std::move(pd_pair.first);
+    param.primitive = std::move(pd_pair.second);
+#else
     param.pd = fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(


### PR DESCRIPTION
oneDNN3.3 enables ACL fixed format kernel support on aarch64 which don't need the workaround for the weights handling during the caching. This PR is to update the logic to remove weights hash checking for the primitive caching.