### PR TITLE
Fix versioning issue: do not reset REVISION to 0 after oneDNN upgrade

### DIFF
--- a/include/ideep.hpp
+++ b/include/ideep.hpp
@@ -45,18 +45,18 @@
 // The fourth is to indicate ideep API change
 // So, ideep version = MAJOR.MINOR.PATCH.REVISION
 // e.g., 3.1.0.0
-// REVISION should +1 after API change if oneDNN is not
-// updated at the same time.
-// REVISION should be reset to 0 after oneDNN update
+// REVISION should +1 after API change in IDEEP.
+// REVISION should NOT be reset to 0 after oneDNN update
 #define IDEEP_VERSION_MAJOR    DNNL_VERSION_MAJOR
 #define IDEEP_VERSION_MINOR    DNNL_VERSION_MINOR
 #define IDEEP_VERSION_PATCH    DNNL_VERSION_PATCH
-#define IDEEP_VERSION_REVISION 0
+#define IDEEP_VERSION_REVISION 1
 
 // Check if ideep version prerequisite is met
 #define IDEEP_PREREQ(major, minor, patch, revision) \
-  (((IDEEP_VERSION_MAJOR << 32) + (IDEEP_VERSION_MINOR << 16) + \
-   (IDEEP_VERSION_PATCH << 8) + (IDEEP_VERSION_REVISION)) >= \
-   ((major << 32) + (minor << 16) + (patch << 8) + (revision)))
+  (((IDEEP_VERSION_MAJOR << 16) + (IDEEP_VERSION_MINOR << 8) + \
+   (IDEEP_VERSION_PATCH << 0)) >= \
+   ((major << 16) + (minor << 8) + (patch << 0)) && \
+   (IDEEP_VERSION_REVISION >= revision))
 
 #endif


### PR DESCRIPTION
Do not reset REVISION to 0 after oneDNN upgrade because Meta may use older versions of oneDNN and we need to check REVISION for API changes.

So, we need to check oneDNN version and ideep REVISION separately
```c
#define IDEEP_PREREQ(major, minor, patch, revision) \
  (((IDEEP_VERSION_MAJOR << 16) + (IDEEP_VERSION_MINOR << 8) + \
   (IDEEP_VERSION_PATCH << 0)) >= \
   ((major << 16) + (minor << 8) + (patch << 0)) && \
   (IDEEP_VERSION_REVISION >= revision))
```

@jgong5 @guobing-chen @yanbing-j  Could you please review? Thanks!