### PR TITLE
Add ideep wrapper for the new serialize API in oneDNN v3.4.1

### DIFF
--- a/include/ideep.hpp
+++ b/include/ideep.hpp
@@ -50,7 +50,7 @@
 #define IDEEP_VERSION_MAJOR    DNNL_VERSION_MAJOR
 #define IDEEP_VERSION_MINOR    DNNL_VERSION_MINOR
 #define IDEEP_VERSION_PATCH    DNNL_VERSION_PATCH
-#define IDEEP_VERSION_REVISION 1
+#define IDEEP_VERSION_REVISION 2
 
 // Check if ideep version prerequisite is met
 #define IDEEP_PREREQ(major, minor, patch, revision) \

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -56,6 +56,16 @@ class tensor : public memory {
       set_g(1);
     }
 
+    // Construct a memory descriptor from a binary blob.
+    // The API is available since oneDNN v3.4.1
+    desc(const std::vector<uint8_t> &blob) : memory::desc(get_dnnl_blob(blob)) {
+      // The groups is serialized into the last sizeof(int) item
+      // TODO: only little endian is supported here.
+      std::vector<uint8_t> groups_bytes(blob.end() - sizeof(int), blob.end());
+      int groups = *reinterpret_cast<int*>(groups_bytes.data());
+      set_g(groups);
+    }
+
     void to_bytes(utils::bytestring& bytes) const {
       utils::to_bytes(bytes, get_data_type());
       utils::to_bytes(bytes, format_kind());
@@ -392,6 +402,23 @@ class tensor : public memory {
       return ret;
     }
 
+    // Returns a binary blob associated with the given memory descriptor
+    // API available since oneDNN v3.4.1
+    std::vector<uint8_t> get_blob() {
+      std::vector<uint8_t> out_blob = memory::desc::get_blob();
+      
+      int groups = g();
+      // We need to add the groups info into the serialized ideep desc.
+      // For example, a 4D FWK weight with groups > 1 will become a 5D oneDNN md,
+      // while FWK still needs it to be a 4D tensor.
+      // ideep desc will wrap the 5D oneDNN md back to a 4D ideep desc
+      // when interacting with the FWK.
+      // TODO: only little endian is supported here.
+      out_blob.insert(out_blob.end(), (uint8_t*)&groups, (uint8_t*)&groups + sizeof(int));
+      
+      return out_blob;
+    }
+
    private:
     /// Returns dimension vector
     inline dims get_internal_dims() const {
@@ -423,6 +450,14 @@ class tensor : public memory {
 
     inline bool is_grouped() const {
       return g() > 1;
+    }
+
+    // We add the groups information into the last sizeof(int) item in the oneDNN blob vector
+    // during the serialization.
+    // We exclude the groups blob here when constructing oneDNN md.
+    std::vector<uint8_t> get_dnnl_blob(const std::vector<uint8_t> &blob) {
+      std::vector<uint8_t> dnnl_blob(blob.begin(), blob.end() - sizeof(int));
+      return dnnl_blob;
     }
 
     int groups = 1;

--- a/include/ideep/tensor.hpp
+++ b/include/ideep/tensor.hpp
@@ -60,7 +60,7 @@ class tensor : public memory {
     // The API is available since oneDNN v3.4.1
     desc(const std::vector<uint8_t> &blob) : memory::desc(get_dnnl_blob(blob)) {
       // The groups is serialized into the last sizeof(int) item
-      // TODO: only little endian is supported here.
+      // We use little endian encoding here for the groups_bytes
       std::vector<uint8_t> groups_bytes(blob.end() - sizeof(int), blob.end());
       int groups = *reinterpret_cast<int*>(groups_bytes.data());
       set_g(groups);
@@ -413,7 +413,7 @@ class tensor : public memory {
       // while FWK still needs it to be a 4D tensor.
       // ideep desc will wrap the 5D oneDNN md back to a 4D ideep desc
       // when interacting with the FWK.
-      // TODO: only little endian is supported here.
+      // We use little endian encoding here when serializing groups
       out_blob.insert(out_blob.end(), (uint8_t*)&groups, (uint8_t*)&groups + sizeof(int));
       
       return out_blob;


### PR DESCRIPTION
## Pitch
Add a wrapper layer for the memory desc serialization and deserialization APIs in oneDNN v3.4.1 into ideep.
Update the `IDEEP_VERSION_REVISION` to 2.

## Description
Starting from oneDNN [v3.4.1](https://github.com/oneapi-src/oneDNN/releases/tag/v3.4.1), the oneDNN memory descriptor serialization API has been introduced ([9b848c859](https://github.com/oneapi-src/oneDNN/commit/9b848c859a6b1d046dd63cf20f817aa9428fb483)).

We added two new APIs in ideep accordingly:
1. For the serialization: `std::vector<uint8_t> get_blob()` is added for [get_blob() of oneDNN md](https://github.com/oneapi-src/oneDNN/blob/v3.4.1/include/oneapi/dnnl/dnnl.hpp#L3135-L3137).

2. For the deserialization, `desc(const std::vector<uint8_t> &blob)` is added for [desc(const std::vector<uint8_t> &blob) of oneDNN md](https://github.com/oneapi-src/oneDNN/blob/v3.4.1/include/oneapi/dnnl/dnnl.hpp#L2836-L2839).

For `groups`, we need to add it into the serialized ideep desc. For example, a 4D FWK weight with groups > 1 will become a 5D oneDNN md, while FWK still needs it to be a 4D tensor. ideep desc will wrap the 5D oneDNN md back to a 4D ideep desc when interacting with the FWK, thus we insert this `groups` information into the end of the blob during the serialization. During the deserialization, we exclude these `groups` bytes when constructing the oneDNN md and save the `groups` into the constructed ideep desc.

These two new APIs will be used in AOTInductor to save and load the prepacked oneDNN weights that're in opaque format.

## Limitation
We have the below two assumptions

1. The `sizeof(int)` (`groups` is of `int` type) is the same on the machine during the serialization and the deserialization.
2. The machine of the serialization and the deserialization are **little endian**.
