### PR TITLE
Move oneDNN Graph python bindings

### DIFF
--- a/include/ideep.hpp
+++ b/include/ideep.hpp
@@ -50,7 +50,7 @@
 #define IDEEP_VERSION_MAJOR    DNNL_VERSION_MAJOR
 #define IDEEP_VERSION_MINOR    DNNL_VERSION_MINOR
 #define IDEEP_VERSION_PATCH    DNNL_VERSION_PATCH
-#define IDEEP_VERSION_REVISION 2
+#define IDEEP_VERSION_REVISION 4
 
 // Check if ideep version prerequisite is met
 #define IDEEP_PREREQ(major, minor, patch, revision) \

--- a/include/ideep/python/binding.hpp
+++ b/include/ideep/python/binding.hpp
@@ -573,15 +573,15 @@ void bind_constant_tensor_cache(pybind11::module& m) {
 }
 
 void initOnednnGraphPythonBindings(PyObject* module) {
-    auto main_module = py::handle(module).cast<py::module>();
-    // Top Level oneDNN Python submodule
-    auto m = main_module.def_submodule("_onednn_graph");
-    m.doc() = R"pbdoc(
-        oneDNN Graph API Python binding
-        -------------------------------
-        .. currentmodule:: onednn_graph_python_binding
-        .. autosummary::
-           :toctree: _generate
+  auto main_module = py::handle(module).cast<py::module>();
+  // Top Level oneDNN Python submodule
+  auto m = main_module.def_submodule("_onednn_graph");
+  m.doc() = R"pbdoc(
+      oneDNN Graph API Python binding
+      -------------------------------
+      .. currentmodule:: onednn_graph_python_binding
+      .. autosummary::
+      :toctree: _generate
     )pbdoc";
 
   bind_status(m);

--- a/include/ideep/python/binding.hpp
+++ b/include/ideep/python/binding.hpp
@@ -572,8 +572,11 @@ void bind_constant_tensor_cache(pybind11::module& m) {
   m.def("get_constant_tensor_cache", &dnnl::graph::get_constant_tensor_cache);
 }
 
-void initOnednnGraphPythonBindings(pybind11::module& m) {
-  m.doc() = R"pbdoc(
+void initOnednnGraphPythonBindings(PyObject* module) {
+    auto main_module = py::handle(module).cast<py::module>();
+    // Top Level oneDNN Python submodule
+    auto m = main_module.def_submodule("_onednn_graph");
+    m.doc() = R"pbdoc(
         oneDNN Graph API Python binding
         -------------------------------
         .. currentmodule:: onednn_graph_python_binding


### PR DESCRIPTION
Move oneDNN Graph python bindings to avoid CMake changes.
And pass `PyObject` module pointer to bindings instead of `pybind11::module` for fewer changes in stock PT