### PR TITLE
Add computation modes to ideep primitive descriptor cache key

### DIFF
--- a/include/ideep/attributes.hpp
+++ b/include/ideep/attributes.hpp
@@ -480,6 +480,12 @@ struct attr_t : public dnnl::primitive_attr {
       }
     }
 
+    // encode computation modes
+    utils::to_bytes(bytes, get_fpmath_mode()); // fpmath mode
+    utils::to_bytes(bytes, get_scratchpad_mode()); // scratchpad mode
+    utils::to_bytes(bytes, get_accumulation_mode()); // accumulation mode
+    utils::to_bytes(bytes, get_deterministic()); // deterministic mode
+
     // Note: depthwise/binary post op, zero points, scales, rnn params are
     // not encoded so far. PD cache is supposed to use in convolution only
     // as a temporary workaround for gemm-based conv pd overhead


### PR DESCRIPTION
fpmath_mode, accumulation_mode, scratchpad_mode and deterministic modes are not encoded as part of the key for the PD cache. This can cause subsequent creations of a primitive to ignore changes to these modes ( e.g. during unit tests ).

In particular changing fpmath_mode between subsequent, calls to otherwise identical matmul has no effect since the pd is loaded from cache from previous call.

Using ONEDNN_VERBOSE we could see that the primitive descriptor is loaded from cache and toggling the fpmath mode on/off between subsequent calls didn't have an effect. This code should resolve that issue and other computation modes are added here ( deterministic, scratchpad and accumulation ) to ensure consistency.