### PR TITLE
Include hash of weights in the key of the primitive cache for aarch64 lowp gemm

### DIFF
--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -1064,6 +1064,9 @@ struct matmul_forward : public dnnl::matmul,
         dst_desc,
         op_attr,
         with_bias,
+#ifdef __aarch64__
+        weights.get_hash(),
+#endif
         omp_get_max_threads());
 #ifdef __aarch64__
     auto pd_pair = fetch_or_create(key, [&]() {
@@ -1219,6 +1222,9 @@ struct matmul_forward : public dnnl::matmul,
         dst_desc,
         op_attr,
         with_bias,
+#ifdef __aarch64__
+        weights.get_hash(),
+#endif
         omp_get_max_threads());
 
     // Create pd and primitive


### PR DESCRIPTION
This goes in hand with oneapi-src/oneDNN#2194 which sets the weights as constant for Arm Compute Library (ACL) lowp gemm objects.

This is a temp fix which is needed because the lowp gemm ACL object in oneDNN is now holding  more state. Hence, we need to make sure that the cahce maps a layer with a specific set of weights to the oneDNN primitive storing those weights.

We're currently working on the proper fix for this which involves making lowp_gemm stateless and fixed-format in ACL and oneDNN.