### PR TITLE
[AArch64] Eltwise bf16 support

### DIFF
--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -43,8 +43,8 @@ struct eltwise_forward : public dnnl::eltwise_forward {
       super(pd).execute(
           stream::default_stream(),
           {{DNNL_ARG_SRC, src_in},
-          {DNNL_ARG_DST, src_in},
-          {DNNL_ARG_SCRATCHPAD, scratchpad}});
+           {DNNL_ARG_DST, src_in},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
       dst.feed_from(src_in);
     
     } else{
@@ -57,8 +57,8 @@ struct eltwise_forward : public dnnl::eltwise_forward {
       super(pd).execute(
           stream::default_stream(),
           {{DNNL_ARG_SRC, src_in},
-          {DNNL_ARG_DST, dst},
-          {DNNL_ARG_SCRATCHPAD, scratchpad}});
+           {DNNL_ARG_DST, dst},
+           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
 #else
     dst.reinit_if_possible(pd.dst_desc());

--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -24,22 +24,42 @@ struct eltwise_forward : public dnnl::eltwise_forward {
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    
+    //ACL does not support bf16 for which f32 up/down casting is needed for better performance
+    bool f32_cast_needed = (src_desc.get_data_type() == data_type::bf16);
+    if (f32_cast_needed){
+      src_desc = src_desc.to_type(data_type::f32);
+      src_in = src_in.reorder_if_differ_in(src_desc);
+    }
 
     auto pd = primitive_desc(
         aengine, aprop_kind, aalgorithm, src_desc, src_desc, alpha, beta, op_attr);
 
-    dst.reinit_if_possible(pd.dst_desc());
-    if (src_in.has_scale()) {
-      dst.set_scale(src_in.get_scale());
+    if (f32_cast_needed){
+    
+      tensor scratchpad(pd.scratchpad_desc());
+
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, src_in},
+          {DNNL_ARG_DST, src_in},
+          {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      dst.feed_from(src_in);
+    
+    } else{
+      dst.reinit_if_possible(pd.dst_desc());
+      if (src_in.has_scale()) {
+        dst.set_scale(src_in.get_scale());
+      }
+      tensor scratchpad(pd.scratchpad_desc());
+
+      super(pd).execute(
+          stream::default_stream(),
+          {{DNNL_ARG_SRC, src_in},
+          {DNNL_ARG_DST, dst},
+          {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
-    tensor scratchpad(pd.scratchpad_desc());
-
-    super(pd).execute(
-        stream::default_stream(),
-        {{DNNL_ARG_SRC, src_in},
-         {DNNL_ARG_DST, dst},
-         {DNNL_ARG_SCRATCHPAD, scratchpad}});
-
+    
     // xpz: ???
     if (dst.has_scale() && aalgorithm == algorithm::eltwise_relu &&
         dst.get_data_type() == data_type::s8) {

--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -25,54 +25,44 @@ struct eltwise_forward : public dnnl::eltwise_forward {
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
+bool f32_cast_needed = false;
 #ifdef __aarch64__
-    // Arm Compute-Library (ACL) + oneDNN do not support bf16 post-ops for which f32 up/down casting is needed for better performance
-    bool f32_cast_needed = (src_desc.get_data_type() == data_type::bf16);
+    // Arm Compute Library (ACL) + oneDNN do not support bf16 post-ops for which f32 up/down casting is needed for better performance
+    f32_cast_needed = (src_desc.get_data_type() == data_type::bf16);
+#endif
+
     if (f32_cast_needed){
       src_desc = src_desc.to_type(data_type::f32);
       src_in = src_in.reorder_if_differ_in(src_desc);
-    }
-#endif
-    auto pd = primitive_desc(
-        aengine, aprop_kind, aalgorithm, src_desc, src_desc, alpha, beta, op_attr);
-#ifdef __aarch64__
-    if (f32_cast_needed){
-    
-      tensor scratchpad(pd.scratchpad_desc());
 
+      auto pd = primitive_desc(
+        aengine, aprop_kind, aalgorithm, src_desc, src_desc, alpha, beta, op_attr);    
+      
+      tensor scratchpad(pd.scratchpad_desc());
       super(pd).execute(
           stream::default_stream(),
           {{DNNL_ARG_SRC, src_in},
            {DNNL_ARG_DST, src_in},
            {DNNL_ARG_SCRATCHPAD, scratchpad}});
+      
       dst.feed_from(src_in);
     
     } else{
+      auto pd = primitive_desc(
+        aengine, aprop_kind, aalgorithm, src_desc, src_desc, alpha, beta, op_attr);
+     
       dst.reinit_if_possible(pd.dst_desc());
       if (src_in.has_scale()) {
         dst.set_scale(src_in.get_scale());
       }
+     
       tensor scratchpad(pd.scratchpad_desc());
-
       super(pd).execute(
           stream::default_stream(),
           {{DNNL_ARG_SRC, src_in},
            {DNNL_ARG_DST, dst},
            {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
-#else
-    dst.reinit_if_possible(pd.dst_desc());
-    if (src_in.has_scale()) {
-      dst.set_scale(src_in.get_scale());
-    }
-    tensor scratchpad(pd.scratchpad_desc());
-
-    super(pd).execute(
-        stream::default_stream(),
-        {{DNNL_ARG_SRC, src_in},
-        {DNNL_ARG_DST, dst},
-        {DNNL_ARG_SCRATCHPAD, scratchpad}});
-#endif
     // xpz: ???
     if (dst.has_scale() && aalgorithm == algorithm::eltwise_relu &&
         dst.get_data_type() == data_type::s8) {

--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -24,17 +24,18 @@ struct eltwise_forward : public dnnl::eltwise_forward {
 
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
-    
-    //ACL does not support bf16 for which f32 up/down casting is needed for better performance
+
+#ifdef __aarch64__
+    // Arm Compute-Library (ACL) + oneDNN do not support bf16 post-ops for which f32 up/down casting is needed for better performance
     bool f32_cast_needed = (src_desc.get_data_type() == data_type::bf16);
     if (f32_cast_needed){
       src_desc = src_desc.to_type(data_type::f32);
       src_in = src_in.reorder_if_differ_in(src_desc);
     }
-
+#endif
     auto pd = primitive_desc(
         aengine, aprop_kind, aalgorithm, src_desc, src_desc, alpha, beta, op_attr);
-
+#ifdef __aarch64__
     if (f32_cast_needed){
     
       tensor scratchpad(pd.scratchpad_desc());
@@ -59,7 +60,19 @@ struct eltwise_forward : public dnnl::eltwise_forward {
           {DNNL_ARG_DST, dst},
           {DNNL_ARG_SCRATCHPAD, scratchpad}});
     }
-    
+#else
+    dst.reinit_if_possible(pd.dst_desc());
+    if (src_in.has_scale()) {
+      dst.set_scale(src_in.get_scale());
+    }
+    tensor scratchpad(pd.scratchpad_desc());
+
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC, src_in},
+        {DNNL_ARG_DST, dst},
+        {DNNL_ARG_SCRATCHPAD, scratchpad}});
+#endif
     // xpz: ???
     if (dst.has_scale() && aalgorithm == algorithm::eltwise_relu &&
         dst.get_data_type() == data_type::s8) {


### PR DESCRIPTION
Description:

For srcdt==bf16 the current implementation of `jit_uni_eltwise_fwd_t` in oneDNN goes to ref implementation which is 10 times slower than f32 jit implementation. First noticed for eltwise_gelu_erf (benchmarked from PyTorch):

Gelu : [[1, 142, 3072]]
ref_implementation : 906 us
jit:sve_256 : 91 us


This patch invokes two reorder layers for up/down bf16/f32 casting in ideep and call the f32 jit eltwise primitive.
After this change, a 10x performance increase was noticed for shape : [1, 1500, 2048]:
Before :   5366 us
After :        556 us
