### PR TITLE
[AArch64] Eltwise bf16 bug fix

### DIFF
--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -32,6 +32,8 @@ bool f32_cast_needed = false;
 #endif
 
     if (f32_cast_needed){
+      dst.reinit_if_possible(src_desc);
+      
       src_desc = src_desc.to_type(data_type::f32);
       src_in = src_in.reorder_if_differ_in(src_desc);
 


### PR DESCRIPTION
A bug was found by PyTorch CI for oneDNN v3.7 (https://github.com/pytorch/pytorch/actions/runs/12739296227/job/35504666636) 

Happens when the bf16 input is generated by `to_mkldnn(torch.bfloat16)` instead of `to(torch.bfloat16)` in PyTorch. This causes the destination tensor descriptors to have number of dimensions, `ndims() == 0`. 

Reinitializing the destination fixes this issue: 
`dst.reinit_if_possible(src_desc);`