### PR TITLE
AArch64: revert eltwise bf16 reorder

### DIFF
--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -25,44 +25,21 @@ struct eltwise_forward : public dnnl::eltwise_forward {
     auto op_attr = dnnl::primitive_attr();
     op_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
 
-bool f32_cast_needed = false;
-#ifdef __aarch64__
-    // Arm Compute Library (ACL) + oneDNN do not support bf16 post-ops for which f32 up/down casting is needed for better performance
-    f32_cast_needed = (src_desc.get_data_type() == data_type::bf16);
-#endif
-
-    if (f32_cast_needed){
-      src_desc = src_desc.to_type(data_type::f32);
-      src_in = src_in.reorder_if_differ_in(src_desc);
-
-      auto pd = primitive_desc(
-        aengine, aprop_kind, aalgorithm, src_desc, src_desc, alpha, beta, op_attr);    
-      
-      tensor scratchpad(pd.scratchpad_desc());
-      super(pd).execute(
-          stream::default_stream(),
-          {{DNNL_ARG_SRC, src_in},
-           {DNNL_ARG_DST, src_in},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
-      
-      dst.feed_from(src_in);
-    
-    } else{
-      auto pd = primitive_desc(
+    auto pd = primitive_desc(
         aengine, aprop_kind, aalgorithm, src_desc, src_desc, alpha, beta, op_attr);
-     
-      dst.reinit_if_possible(pd.dst_desc());
-      if (src_in.has_scale()) {
-        dst.set_scale(src_in.get_scale());
-      }
-     
-      tensor scratchpad(pd.scratchpad_desc());
-      super(pd).execute(
-          stream::default_stream(),
-          {{DNNL_ARG_SRC, src_in},
-           {DNNL_ARG_DST, dst},
-           {DNNL_ARG_SCRATCHPAD, scratchpad}});
+
+    dst.reinit_if_possible(pd.dst_desc());
+    if (src_in.has_scale()) {
+      dst.set_scale(src_in.get_scale());
     }
+    tensor scratchpad(pd.scratchpad_desc());
+
+    super(pd).execute(
+        stream::default_stream(),
+        {{DNNL_ARG_SRC, src_in},
+         {DNNL_ARG_DST, dst},
+         {DNNL_ARG_SCRATCHPAD, scratchpad}});
+
     // xpz: ???
     if (dst.has_scale() && aalgorithm == algorithm::eltwise_relu &&
         dst.get_data_type() == data_type::s8) {

--- a/include/ideep/operators/eltwise.hpp
+++ b/include/ideep/operators/eltwise.hpp
@@ -32,8 +32,6 @@ bool f32_cast_needed = false;
 #endif
 
     if (f32_cast_needed){
-      dst.reinit_if_possible(src_desc);
-      
       src_desc = src_desc.to_type(data_type::f32);
       src_in = src_in.reorder_if_differ_in(src_desc);
 


### PR DESCRIPTION
[This PR](https://github.com/uxlfoundation/oneDNN/pull/2982) enables the type conversion in. 
We can revert the need for explicit reorder from bf16->fp32 and back. 

Marking this as a draft PR since this needs oneDNN upgrade. 