### PR TITLE
aarch64: Remove computation cache from conv, matmul, inner product

### DIFF
--- a/include/ideep/lru_cache.hpp
+++ b/include/ideep/lru_cache.hpp
@@ -212,6 +212,20 @@ class computation_cache {
     return t_store_;
   }
 };
+
+struct placeholder_lru {
+  void clear() {};
+};
+
+// Placeholder cache to be used where computation cache
+// isn't required but expected. Missing methods should
+// be added as required
+class placeholder_computation_cache {
+ public:
+  static inline placeholder_lru t_store() {
+    return placeholder_lru();
+  }
+};
 } // namespace utils
 } // namespace ideep
 #endif

--- a/include/ideep/lru_cache.hpp
+++ b/include/ideep/lru_cache.hpp
@@ -221,9 +221,11 @@ struct placeholder_lru {
 // isn't required but expected. Missing methods should
 // be added as required
 class placeholder_computation_cache {
+ private:
+  static placeholder_lru lru;
  public:
-  static inline placeholder_lru t_store() {
-    return placeholder_lru();
+  static inline placeholder_lru& t_store() {
+    return lru;
   }
 };
 } // namespace utils

--- a/include/ideep/operators/conv.hpp
+++ b/include/ideep/operators/conv.hpp
@@ -294,7 +294,7 @@ struct conv_deconv_utils {
 struct convolution_forward
     : public dnnl::convolution_forward,
 #ifdef __aarch64__
-      utils::computation_cache<std::pair<dnnl::convolution_forward::primitive_desc, dnnl::convolution_forward> > {
+      utils::placeholder_computation_cache {
 #else
       utils::computation_cache<dnnl::convolution_forward::primitive_desc> {
 #endif
@@ -1417,54 +1417,37 @@ struct convolution_forward
       dst_desc_query = dst_desc.to_format(memory_format);
     }
 
-    auto key = utils::create_key(
-        aprop_kind,
-        aalgorithm,
-        src_desc_query,
-        weights_desc_query,
-        bias_desc_query,
-        dst_desc_query,
-        with_bias,
-        strides,
-        dilates,
-        padding_l,
-        padding_r,
-        attr,
-        omp_get_max_threads());
-
     dnnl::convolution_forward::primitive_desc pd;
-    return fetch_or_create(key, [&]() {
-      if (with_bias) {
-         pd = primitive_desc(
-            aengine,
-            aprop_kind,
-            aalgorithm,
-            src_desc_query,
-            weights_desc_query,
-            bias_desc_query,
-            dst_desc_query,
-            strides,
-            dilates,
-            padding_l,
-            padding_r,
-            attr
-            );
-      } else {
+    if (with_bias) {
         pd = primitive_desc(
-            aengine,
-            aprop_kind,
-            aalgorithm,
-            src_desc_query,
-            weights_desc_query,
-            dst_desc_query,
-            strides,
-            dilates,
-            padding_l,
-            padding_r,
-            attr);
-      }
-      return std::make_pair(pd, super(pd));
-    });
+          aengine,
+          aprop_kind,
+          aalgorithm,
+          src_desc_query,
+          weights_desc_query,
+          bias_desc_query,
+          dst_desc_query,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          attr
+          );
+    } else {
+      pd = primitive_desc(
+          aengine,
+          aprop_kind,
+          aalgorithm,
+          src_desc_query,
+          weights_desc_query,
+          dst_desc_query,
+          strides,
+          dilates,
+          padding_l,
+          padding_r,
+          attr);
+    }
+    return {pd, super(pd)};
   }
 #else
   template <bool with_bias>

--- a/include/ideep/operators/inner_product.hpp
+++ b/include/ideep/operators/inner_product.hpp
@@ -35,7 +35,7 @@ struct inner_product_forward_params {
 struct inner_product_forward
     : public dnnl::inner_product_forward,
 #ifdef __aarch64__
-      utils::computation_cache<std::pair<dnnl::inner_product_forward::primitive_desc, dnnl::inner_product_forward>> {
+      utils::placeholder_computation_cache {
 #else
       utils::computation_cache<dnnl::inner_product_forward::primitive_desc> {
 #endif
@@ -254,27 +254,15 @@ struct inner_product_forward
       const attr_t& attr = attr_t(),
       const prop_kind aprop_kind = prop_kind::forward,
       const engine& aengine = engine::cpu_engine()) {
-    auto key = utils::create_key(
-        aprop_kind,
-        src_desc,
-        weights_desc,
-        bias_desc,
-        dst_desc,
-        attr,
-        with_bias,
-        omp_get_max_threads());
-
-    return fetch_or_create(key, [&]() {
-      dnnl::inner_product_forward::primitive_desc pd;
-      if (with_bias) {
-        pd = primitive_desc(
-            aengine, aprop_kind, src_desc, weights_desc, bias_desc, dst_desc, attr);
-      } else {
-        pd = primitive_desc(
-            aengine, aprop_kind, src_desc, weights_desc, dst_desc, attr);
-      }
-      return std::make_pair(pd, super(pd));
-    });
+    dnnl::inner_product_forward::primitive_desc pd;
+    if (with_bias) {
+      pd = primitive_desc(
+          aengine, aprop_kind, src_desc, weights_desc, bias_desc, dst_desc, attr);
+    } else {
+      pd = primitive_desc(
+          aengine, aprop_kind, src_desc, weights_desc, dst_desc, attr);
+    }
+    return std::make_pair(pd, super(pd));
   }
 #else
   static primitive_desc get_primitive_desc(

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -895,7 +895,7 @@ struct matmul_forward : public dnnl::matmul,
       param.pd = primitive_desc(
           aengine, src_desc, weights_desc, dst_desc, op_attr);
     }
-    param.primitive = std::move(super(param.pd));
+    param.primitive = super(param.pd);
 #else
     auto key = utils::create_key(
         src_desc,
@@ -1073,7 +1073,7 @@ struct matmul_forward : public dnnl::matmul,
       param.pd =  primitive_desc(
           aengine, src_desc, weights_desc, dst_desc, op_attr);
     }
-    param.primitive = std::move(super(param.pd));
+    param.primitive = super(param.pd);
 #else
     auto key = utils::create_key(
         src_desc,
@@ -1225,7 +1225,7 @@ struct matmul_forward : public dnnl::matmul,
       param.pd = primitive_desc(
           aengine, src_desc, weights.get_desc(), dst_desc, op_attr);
     }
-    param.primitive = std::move(super(param.pd));
+    param.primitive = super(param.pd);
 #else
     auto key = utils::create_key(
         src_desc,

--- a/include/ideep/operators/matmul.hpp
+++ b/include/ideep/operators/matmul.hpp
@@ -49,7 +49,7 @@ struct matmul_forward_params {
 
 struct matmul_forward : public dnnl::matmul,
 #ifdef __aarch64__
-                        utils::computation_cache<std::pair<dnnl::matmul::primitive_desc, dnnl::matmul> > {
+                        utils::placeholder_computation_cache {
 #else
                         utils::computation_cache<dnnl::matmul::primitive_desc> {
 #endif
@@ -887,6 +887,16 @@ struct matmul_forward : public dnnl::matmul,
       dst_desc = dst.get_desc().to_type(dst_data_type);
     }
 
+#ifdef __aarch64__
+    if (with_bias) {
+      param.pd = primitive_desc(
+          aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
+    } else {
+      param.pd = primitive_desc(
+          aengine, src_desc, weights_desc, dst_desc, op_attr);
+    }
+    param.primitive = std::move(super(param.pd));
+#else
     auto key = utils::create_key(
         src_desc,
         weights_desc,
@@ -895,21 +905,6 @@ struct matmul_forward : public dnnl::matmul,
         op_attr,
         with_bias,
         omp_get_max_threads());
-
-#ifdef __aarch64__
-    auto pd_pair = fetch_or_create(key, [&]() {
-      if (with_bias) {
-        param.pd = primitive_desc(
-            aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
-      } else {
-        param.pd = primitive_desc(
-            aengine, src_desc, weights_desc, dst_desc, op_attr);
-      }
-      return std::make_pair(param.pd, super(param.pd));
-    });
-    param.pd = std::move(pd_pair.first);
-    param.primitive = std::move(pd_pair.second);
-#else
     param.pd = fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(
@@ -1070,6 +1065,16 @@ struct matmul_forward : public dnnl::matmul,
     if (!dst.is_empty()) {
       dst_desc = dst.get_desc().to_type(dst_data_type);
     }
+#ifdef __aarch64__
+    if (with_bias) {
+      param.pd =  primitive_desc(
+          aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
+    } else {
+      param.pd =  primitive_desc(
+          aengine, src_desc, weights_desc, dst_desc, op_attr);
+    }
+    param.primitive = std::move(super(param.pd));
+#else
     auto key = utils::create_key(
         src_desc,
         weights_desc,
@@ -1078,20 +1083,6 @@ struct matmul_forward : public dnnl::matmul,
         op_attr,
         with_bias,
         omp_get_max_threads());
-#ifdef __aarch64__
-    auto pd_pair = fetch_or_create(key, [&]() {
-      if (with_bias) {
-        param.pd =  primitive_desc(
-            aengine, src_desc, weights_desc, bias_desc, dst_desc, op_attr);
-      } else {
-        param.pd =  primitive_desc(
-            aengine, src_desc, weights_desc, dst_desc, op_attr);
-      }
-      return std::make_pair(param.pd, super(param.pd));
-    });
-    param.pd = std::move(pd_pair.first);
-    param.primitive = std::move(pd_pair.second);
-#else
     param.pd = fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(
@@ -1225,6 +1216,17 @@ struct matmul_forward : public dnnl::matmul,
       bias_desc = {bias.get_dims(), data_type::f32, bia_tag};
     }
 
+    // Create pd and primitive
+#ifdef __aarch64__
+    if (with_bias) {
+      param.pd = primitive_desc(
+          aengine, src_desc, weights.get_desc(), bias_desc, dst_desc, op_attr);
+    } else {
+      param.pd = primitive_desc(
+          aengine, src_desc, weights.get_desc(), dst_desc, op_attr);
+    }
+    param.primitive = std::move(super(param.pd));
+#else
     auto key = utils::create_key(
         src_desc,
         weights.get_desc(),
@@ -1233,22 +1235,6 @@ struct matmul_forward : public dnnl::matmul,
         op_attr,
         with_bias,
         omp_get_max_threads());
-
-    // Create pd and primitive
-#ifdef __aarch64__
-    auto pd_pair = fetch_or_create(key, [&]() {
-      if (with_bias) {
-        param.pd = primitive_desc(
-            aengine, src_desc, weights.get_desc(), bias_desc, dst_desc, op_attr);
-      } else {
-        param.pd = primitive_desc(
-            aengine, src_desc, weights.get_desc(), dst_desc, op_attr);
-      }
-      return std::make_pair(param.pd, super(param.pd));
-    });
-    param.pd = std::move(pd_pair.first);
-    param.primitive = std::move(pd_pair.second);
-#else
     param.pd = fetch_or_create(key, [&]() {
       if (with_bias) {
         return primitive_desc(


### PR DESCRIPTION
conv, matmul and inner product have been converted to being stateless in ACL, thus there is no longer a need for the computation cache. This has been replaced with a dummy cache as the cache is still expected to exist. The dummy cache can be removed once deconv is also converted to stateless.